### PR TITLE
Update depreciated functions.

### DIFF
--- a/src/media.cpp
+++ b/src/media.cpp
@@ -245,7 +245,7 @@ void FeBaseStream::free_packet( AVPacket *pkt )
 void FeBaseStream::free_frame( AVFrame *frame )
 {
 #if (LIBAVCODEC_VERSION_INT >= AV_VERSION_INT( 54, 28, 0 ))
-	avcodec_free_frame( &frame );
+	av_frame_free( &frame );
 #else
 	av_free( frame );
 #endif
@@ -363,7 +363,7 @@ void FeVideoImp::preload()
 			// decompress packet and put it in our frame queue
 			//
 			int got_frame = 0;
-			AVFrame *raw_frame = avcodec_alloc_frame();
+			AVFrame *raw_frame = av_frame_alloc();
 
 			int len = avcodec_decode_video2( codec_ctx, raw_frame,
 									&got_frame, packet );
@@ -542,7 +542,7 @@ void FeVideoImp::video_thread()
 					// decompress packet and put it in our frame queue
 					//
 					int got_frame = 0;
-					AVFrame *raw_frame = avcodec_alloc_frame();
+					AVFrame *raw_frame = av_frame_alloc();
 
 					int len = avcodec_decode_video2( codec_ctx, raw_frame,
 											&got_frame, packet );
@@ -978,7 +978,7 @@ bool FeMedia::onGetData( Chunk &data )
 			}
 		}
 #else
-		AVFrame *frame = avcodec_alloc_frame();
+		AVFrame *frame = av_frame_alloc();
 
 		//
 		// TODO: avcodec_decode_audio4() can return multiple frames per packet depending on the codec.


### PR DESCRIPTION
avcodec_free_frame  is deprecated, changed to av_frame_free
avcodec_alloc_frame deprecated, changed to av_frame_alloc

https://github.com/FFmpeg/FFmpeg/blob/0eec06ed8747923faa6a98e474f224d922dc487d/doc/APIchanges

2013-12-11 - 29c83d2 / b9fb59d,409a143 / 9431356,44967ab / d7b3ee9 - lavc 55.45.101 / 55.28.1 - avcodec.h
  av_frame_alloc(), av_frame_unref() and av_frame_free() now can and should be
  used instead of avcodec_alloc_frame(), avcodec_get_frame_defaults() and
  avcodec_free_frame() respectively. The latter three functions are deprecated.
