### PR TITLE
Vertical video play bug?

### DIFF
--- a/src/media.cpp
+++ b/src/media.cpp
@@ -292,6 +292,7 @@ FeVideoImp::FeVideoImp( FeMedia *p )
 		m_video_thread( &FeVideoImp::video_thread, this ),
 		m_parent( p ),
 		run_video_thread( false ),
+		sws_ctx( NULL ),
 		sws_flags( SWS_FAST_BILINEAR ),
 		display_frame( NULL )
 {


### PR DESCRIPTION
When vertical videos are played, they are cut off on the right side with garbage.  Looks like some sort of memory allocation issue.

Video of the problem, watch the right side of the screen capture.
https://www.youtube.com/watch?v=K5fzGuVADo4

Running ArchLinux x86. Doubtful it affects Windows.