### PR TITLE
Choose shortest match when selecting ROM to run

### DIFF
--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -1184,7 +1184,9 @@ int FeSettings::run( int &minimum_run_seconds )
 			// Found the rom to run
 			//
 			rom_path = path;
-			romfilename = in_list.front();
+			for ( std::vector<std::string>::const_iterator i = in_list.begin(); i != in_list.end(); ++i )
+				if ( romfilename.empty() || romfilename.length() > i->length() )
+					romfilename = *i;
 			found = true;
 			break;
 		}


### PR DESCRIPTION
This is a small fix to how ROM file selection works. Originally, the first filename found that starts with the selected ROM name was selected, which could be wrong in certain cases (e.g. "Sonic the Hedgehog 3" might be chosen where the selected ROM name was "Sonic the Hedgehog", even though a ROM file called "Sonic the Hedgehog.md" exists). This pull request changes the behaviour so that the shortest entry from those matched is selected.