### PR TITLE
Fix x86_64 compilation with MingW

### DIFF
--- a/extlibs/miniz/miniz.c
+++ b/extlibs/miniz/miniz.c
@@ -2848,7 +2848,7 @@ void *tdefl_write_image_to_png_file_in_memory(const void *pImage, int w, int h, 
   #include <stdio.h>
   #include <sys/stat.h>
 
-  #if defined(_MSC_VER) || defined(__MINGW64__)
+  #if (defined(_MSC_VER) && (defined(_WIN32) || defined(_WIN64)))
     static FILE *mz_fopen(const char *pFilename, const char *pMode)
     {
       FILE* pFile = NULL;


### PR DESCRIPTION
linux cross compile setup (mxe).
i386 mingw builds fine.
x86_64 does not:

```make
In file included from src/zip.cpp:25:0:
extlibs/miniz/miniz.c: In function 'FILE* mz_fopen(const char*, const char*)':
extlibs/miniz/miniz.c:2855:39: error: 'fopen_s' was not declared in this scope
       fopen_s(&pFile, pFilename, pMode);
                                       ^
extlibs/miniz/miniz.c: In function 'FILE* mz_freopen(const char*, const char*, FILE*)':
extlibs/miniz/miniz.c:2861:50: error: 'freopen_s' was not declared in this scope
       if (freopen_s(&pFile, pPath, pMode, pStream))
                                                  ^
Makefile:289: recipe for target 'obj/zip.o' failed
```

http://build.zaplabs.com:8010/builders/attractmode-windows-x86_64/builds/12