### PR TITLE
Minor build changes for compling with clang on OSX.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@
 CC=$(CROSS)gcc
 CPP=$(CROSS)g++
 CFLAGS=
+STRIP=$(CROSS)strip
 PKG_CONFIG=$(CROSS)pkg-config
 AR=$(CROSS)ar
 ARFLAGS=rc
@@ -190,10 +191,10 @@ ifneq ($(NO_SWF),1)
  LIBS += -ljpeg -lz
 
  ifneq ($(FE_WINDOWS_COMPILE),1)
-  CFLAGS += -rdynamic
   ifeq ($(FE_MACOSX_COMPILE),1)
    LIBS += -ldl -framework OpenGL
   else
+  CFLAGS += -Wl,--export-dynamic
    LIBS += -ldl -lGL
   endif
  else
@@ -232,7 +233,7 @@ ifeq ($(FE_DEBUG),1)
  CFLAGS += -g -Wall
  FE_FLAGS += -DFE_DEBUG
 else
- CFLAGS += -O2 -s -DNDEBUG
+ CFLAGS += -O2 -DNDEBUG
 endif
 
 ifeq ($(FE_RPI),1)
@@ -315,6 +316,9 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.mm $(DEP) | $(OBJ_DIR)
 
 $(EXE): $(OBJ) $(EXPAT) $(SQUIRREL) $(AUDIO)
 	$(CPP) -o $@ $^ $(CFLAGS) $(FE_FLAGS) $(LIBS)
+ifneq ($(FE_DEBUG),1)
+	$(STRIP) $@
+endif
 
 .PHONY: clean
 
@@ -528,7 +532,7 @@ $(OBJ_DIR)/libgameswf.a: $(GAMESWFOBJS) | $(GAMESWF_OBJ_DIR) $(GSBASE_OBJ_DIR)
 	$(AR) $(ARFLAGS) $@ $(GAMESWFOBJS)
 
 $(GAMESWF_OBJ_DIR)/%.o: $(EXTLIBS_DIR)/gameswf/gameswf/%.cpp | $(GAMESWF_OBJ_DIR)
-	$(CPP) -c $< -o $@ $(CFLAGS) -Wno-deprecated -fpermissive
+	$(CPP) -c $< -o $@ $(CFLAGS) -Wno-deprecated
 
 $(GAMESWF_OBJ_DIR):
 	$(MD) $@

--- a/extlibs/gameswf/base/triangulate_impl.h
+++ b/extlibs/gameswf/base/triangulate_impl.h
@@ -153,13 +153,68 @@ int	compare_vertices(const void* a, const void* b)
 
 
 template<class coord_t>
-inline bool	edges_intersect_sub(const array<poly_vert<coord_t> >& sorted_verts, int e0v0, int e0v1, int e1v0, int e1v1)
+inline bool	edges_intersect_sub(const array<poly_vert<coord_t> >& sorted_verts, int e0v0i, int e0v1i, int e1v0i, int e1v1i)
 // Return true if edge (e0v0,e0v1) intersects (e1v0,e1v1).
+//
+// Specialized for coord_t.
 {
-	// Need to specialize this on coord_t, in order to get it
-	// correct and avoid overflow.
-	compiler_assert(0);
-	return -1;
+	// If e1v0,e1v1 are on opposite sides of e0, and e0v0,e0v1 are
+	// on opposite sides of e1, then the segments cross.  These
+	// are all determinant checks.
+
+	// The main degenerate case we need to watch out for is if
+	// both segments are zero-length.
+	//
+	// If only one is degenerate, our tests are still OK.
+
+	const vec2<coord_t>&	e0v0 = sorted_verts[e0v0i].m_v;
+	const vec2<coord_t>&	e0v1 = sorted_verts[e0v1i].m_v;
+	const vec2<coord_t>&	e1v0 = sorted_verts[e1v0i].m_v;
+	const vec2<coord_t>&	e1v1 = sorted_verts[e1v1i].m_v;
+
+	// Note: exact equality here.  I think the reason to use
+	// epsilons would be underflow in case of very small
+	// determinants.  Our determinants are doubles, so I think
+	// we're good.
+	if (e0v0.x == e0v1.x && e0v0.y == e0v1.y)
+	{
+		// e0 is zero length.
+		if (e1v0.x == e1v1.x && e1v0.y == e1v1.y)
+		{
+			// Both edges are zero length.
+			// They intersect only if they're coincident.
+			return e0v0.x == e1v0.x && e0v0.y == e1v0.y;
+		}
+	}
+
+	// See if e1 crosses line of e0.
+	double	det10 = determinant_coord(e0v0, e0v1, e1v0);
+	double	det11 = determinant_coord(e0v0, e0v1, e1v1);
+
+	// Note: we do > 0, which means a vertex on a line counts as
+	// intersecting.  In general, if one vert is on the other
+	// segment, we have to go searching along the path in either
+	// direction to see if it crosses or not, and it gets
+	// complicated.  Better to treat it as intersection.
+
+	if (det10 * det11 > 0)
+	{
+		// e1 doesn't cross the line of e0.
+		return false;
+	}
+
+	// See if e0 crosses line of e1.
+	double	det00 = determinant_coord(e1v0, e1v1, e0v0);
+	double	det01 = determinant_coord(e1v0, e1v1, e0v1);
+
+	if (det00 * det01 > 0)
+	{
+		// e0 doesn't cross the line of e1.
+		return false;
+	}
+
+	// They both cross each other; the segments intersect.
+	return true;
 }
 
 

--- a/extlibs/gameswf/base/vert_types.h
+++ b/extlibs/gameswf/base/vert_types.h
@@ -51,6 +51,13 @@ inline double	determinant_float(const vec2<float>& a, const vec2<float>& b, cons
 		- (double(b.y) - double(a.y)) * (double(c.x) - double(a.x));
 }
 
+template <class coord_t>
+inline double   determinant_coord(const vec2<coord_t>& a, const vec2<coord_t>& b, const vec2<coord_t>& c)
+{
+	return (double(b.x) - double(a.x)) * (double(c.y) - double(a.y))
+		- (double(b.y) - double(a.y)) * (double(c.x) - double(a.x));
+}
+
 
 // This is not really valid!  double has only 52 mantissa bits, but we
 // need about 65 for worst-case 32-bit determinant.
@@ -76,8 +83,10 @@ inline sint64	determinant_sint16(const vec2<sint16>& a, const vec2<sint16>& b, c
 template<class coord_t>
 inline int	vertex_left_test(const vec2<coord_t>& a, const vec2<coord_t>& b, const vec2<coord_t>& c)
 {
-	compiler_assert(0);	// must specialize
-	return -1;
+	double	det = determinant_coord(a, b, c);
+	if (det > 0) return 1;
+	else if (det < 0) return -1;
+	else return 0;
 }
 
 


### PR DESCRIPTION
game_swf changes are not tested for correct output, but they do allow it to compile without the relaxed flag and can't be any worst than the compile_assert that was there.

-rdynamic is not necessary, not supported on osx, but changed to an linker flag.
-s moved to it's own command, as its not supported with llvm compilers.