### PR TITLE
Fix missing UINT64_C when compiling with ffmpeg support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,11 @@ endif
 
 ifeq ($(NO_MOVIE),1)
  FE_FLAGS += -DNO_MOVIE
- LIBS += -lsfml-audio
+ ifeq ($(WINDOWS_STATIC),1)
+  LIBS += -lsfml-audio-s
+ else
+  LIBS += -lsfml-audio
+ endif
  AUDIO =
 else
  TEMP_LIBS += libavformat libavcodec libavutil libswscale
@@ -331,6 +335,8 @@ else
  CFLAGS += -I$(EXTLIBS_DIR)/audio/include
  AUDIO = $(OBJ_DIR)/libaudio.a
 endif
+
+CFLAGS += -D__STDC_CONSTANT_MACROS
 
 LIBS += $(shell $(PKG_CONFIG) --libs $(TEMP_LIBS))
 CFLAGS += $(shell $(PKG_CONFIG) --cflags $(TEMP_LIBS))

--- a/src/media.cpp
+++ b/src/media.cpp
@@ -20,11 +20,6 @@
  *
  */
 
-#ifndef INT64_C
-#define INT64_C(c) (c ## LL)
-#define UINT64_C(c) (c ## ULL)
-#endif
-
 #include "media.hpp"
 #include "zip.hpp"
 #include <SFML/System.hpp>


### PR DESCRIPTION
Also fix sfml-audio linking on -DNO_MOVIE with static windows.

    x86_64-w64-mingw32.static-g++ -c extlibs/audio/Audio/SoundStream.cpp -o obj/audiolib/SoundStream.o  -DSFML_STATIC -DSFML_STATIC -I/opt/mxe/usr/x86_64-w64-mingw32.static/include/freetype2 -DGLEW_STATIC -I/opt/mxe/usr/x86_64-w64-mingw32.static/include/AL -DAL_LIBTYPE_STATIC -I/opt/mxe/usr/x86_64-w64-mingw32.static/include   -mconsole -O2 -DNDEBUG -Iextlibs/audio/include -I/opt/mxe/usr/x86_64-w64-mingw32.static/include/freetype2 -I/opt/mxe/usr/x86_64-w64-mingw32.static/include/AL -DAL_LIBTYPE_STATIC -I/opt/mxe/usr/x86_64-w64-mingw32.static/include   -Iextlibs/expat -Iextlibs/squirrel/include -Iextlibs/sqrat/include -Iextlibs/gameswf
    In file included from /opt/mxe/usr/x86_64-w64-mingw32.static/include/libavutil/avutil.h:288:0,
                     from /opt/mxe/usr/x86_64-w64-mingw32.static/include/libavutil/samplefmt.h:24,
                     from /opt/mxe/usr/x86_64-w64-mingw32.static/include/libavcodec/avcodec.h:31,
                     from extlibs/gameswf/gameswf/gameswf_render_handler_ogl.cpp:33:
    /opt/mxe/usr/x86_64-w64-mingw32.static/include/libavutil/common.h:30:2: error: #error missing -D__STDC_CONSTANT_MACROS / #define __STDC_CONSTANT_MACROS
     #error missing -D__STDC_CONSTANT_MACROS / #define __STDC_CONSTANT_MACROS
      ^
    x86_64-w64-mingw32.static-ar rc obj/libsqstdlib.a obj/sqstdlib/sqstdblob.o obj/sqstdlib/sqstdio.o obj/sqstdlib/sqstdstream.o obj/sqstdlib/sqstdmath.o obj/sqstdlib/sqstdstring.o obj/sqstdlib/sqstdaux.o obj/sqstdlib/sqstdsystem.o obj/sqstdlib/sqstdrex.o
    x86_64-w64-mingw32.static-ar rc obj/libaudio.a obj/audiolib/ALCheck.o obj/audiolib/AudioDevice.o obj/audiolib/Listener.o obj/audiolib/SoundSource.o obj/audiolib/SoundStream.o
    In file included from /opt/mxe/usr/x86_64-w64-mingw32.static/include/libavutil/avutil.h:288:0,
                     from /opt/mxe/usr/x86_64-w64-mingw32.static/include/libavutil/samplefmt.h:24,
                     from /opt/mxe/usr/x86_64-w64-mingw32.static/include/libavcodec/avcodec.h:31,
                     from extlibs/gameswf/gameswf/gameswf_render_handler_ogl.cpp:33:
    /opt/mxe/usr/x86_64-w64-mingw32.static/include/libavutil/common.h: In function 'int32_t av_clipl_int32_c(int64_t)':
    /opt/mxe/usr/x86_64-w64-mingw32.static/include/libavutil/common.h:209:47: error: 'UINT64_C' was not declared in this scope
         if ((a+0x80000000u) & ~UINT64_C(0xFFFFFFFF)) return (int32_t)((a>>63) ^ 0x7FFFFFFF);
                                                   ^