### PR TITLE
fix issue #183, initial startup crash when nothing has been configured

### DIFF
--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -1167,8 +1167,6 @@ bool FeSettings::set_display( int index )
 	//
 	if ( index >= (int)m_displays.size() )
 		m_current_display = m_displays.size()-1;
-	else if ( index < 0 )
-		m_current_display = 0;
 	else
 		m_current_display = index;
 


### PR DESCRIPTION
This seems right because `init_display` checks for -1 and creates the romlist which prevents the crash.