### PR TITLE
package scripts, only remove abbreviated object from version tag

### DIFF
--- a/util/osx/create-pkg.sh
+++ b/util/osx/create-pkg.sh
@@ -24,8 +24,7 @@ cd ..
 ### end: init
 
 LASTTAG=$(git describe --tag --abbrev=0)
-VERSION=$(git describe --tag | sed 's/-[^-]*$//')
-REVCOUNT=$(git rev-list ${LASTTAG}..HEAD --no-merges --count)
+VERSION=$(git describe --tag | sed 's/-[^-]\{8\}$//')
 BUNDLEVERSION=${VERSION//[v-]/.}; BUNDLEVERSION=${BUNDLEVERSION#"."}
 SHORTVERSION=${LASTTAG//v/}
 

--- a/util/win/create-pkg.sh
+++ b/util/win/create-pkg.sh
@@ -24,7 +24,7 @@ cd ..
 ### end: init
 
 LASTTAG=$(git describe --tag --abbrev=0)
-VERSION=$(git describe --tag | sed 's/-[^-]*$//')
+VERSION=$(git describe --tag | sed 's/-[^-]\{8\}$//')
 
 function finish {
 	if [[ ! -z $SCRATCH && -d $SCRATCH ]] ; then


### PR DESCRIPTION
fixes tag v2.0.0-rc1 resuting in v2.0.0.
also removed unused variable REFCOUNT.