### PR TITLE
minor build cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ endif
 
 ifeq ($(USE_LIBARCHIVE),1)
  FE_FLAGS += -DUSE_LIBARCHIVE
- TEMP_LIBS += libarchive zlib
+ TEMP_LIBS += libarchive
 else
  CFLAGS += -I$(EXTLIBS_DIR)/miniz
 endif
@@ -352,8 +352,8 @@ endif
 
 CFLAGS += -D__STDC_CONSTANT_MACROS
 
-LIBS += $(shell $(PKG_CONFIG) --libs $(TEMP_LIBS))
-CFLAGS += $(shell $(PKG_CONFIG) --cflags $(TEMP_LIBS))
+LIBS := $(LIBS) $(shell $(PKG_CONFIG) --libs $(TEMP_LIBS))
+CFLAGS := $(CFLAGS) $(shell $(PKG_CONFIG) --cflags $(TEMP_LIBS))
 
 EXE = $(EXE_BASE)$(EXE_EXT)
 

--- a/extlibs/gameswf/base/container.cpp
+++ b/extlibs/gameswf/base/container.cpp
@@ -46,7 +46,7 @@ void	tu_string::resize(int new_size)
 
 	if (using_heap() == false)
 	{
-		if (new_size <= sizeof(m_union.m_local.m_buffer))
+		if (new_size <= (int)sizeof(m_union.m_local.m_buffer))
 		{
 			// Stay with internal storage.
 			m_union.m_local.m_bufsize_minus_length = (char) (sizeof(m_union.m_local.m_buffer) - new_size);
@@ -75,7 +75,7 @@ void	tu_string::resize(int new_size)
 	else
 	{
 		// Currently using heap storage.
-		if (new_size <= sizeof(m_union.m_local.m_buffer))
+		if (new_size <= (int)sizeof(m_union.m_local.m_buffer))
 		{
 			// Switch to local storage.
 

--- a/extlibs/gameswf/base/grid_index.h
+++ b/extlibs/gameswf/base/grid_index.h
@@ -735,7 +735,7 @@ struct grid_index_box
 	void	add(const box_t& bound, payload p)
 	// Insert a box, with the given payload, into our index.
 	{
-		index_box<int>	ib = get_containing_cells_clamped(bound);
+		// index_box<int>	ib = get_containing_cells_clamped(bound);
 
 		grid_entry_t*	new_entry = new grid_entry_t;
 		new_entry->bound = bound;

--- a/extlibs/gameswf/base/image_filters.cpp
+++ b/extlibs/gameswf/base/image_filters.cpp
@@ -715,8 +715,8 @@ void	zoom(image_base* src, image_base* dst)
   rgba;
 
   int x, y, sx, sy, *sax, *say, *csax, *csay, csx, csy, ex, ey, t1, t2;
-  rgba *c00, *c01, *c10, *c11, *sp, *csp, *dp;
-  int sgap, dgap;
+  rgba *c00, *c01, *c10, *c11, *csp, *dp;
+  int dgap;
 
   /* For interpolation: assume source dimension is one pixel */
   /* smaller to avoid overflow on right and bottom edge.     */
@@ -748,9 +748,8 @@ void	zoom(image_base* src, image_base* dst)
   }
 
   /* Pointer setup */
-  sp = csp = (rgba *) src->m_data;
+  csp = (rgba *) src->m_data;
   dp = (rgba *) dst->m_data;
-  sgap = src->m_pitch - src->m_width * 4;
   dgap = dst->m_pitch - dst->m_width * 4;
 
 	/* Interpolating Zoom */

--- a/extlibs/gameswf/base/logger.cpp
+++ b/extlibs/gameswf/base/logger.cpp
@@ -10,6 +10,7 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+#include <iostream>
 
 
 namespace logger
@@ -33,10 +34,10 @@ namespace logger
 	void standard_logger(log_type e, const char* message)
 	{
 		if (e == ERROR) {
-			fprintf(stderr, message);
+			std::cerr << message << std::endl;
 		} else {
 			// NORMAL or VERBOSE
-			printf(message);
+			std::cout << message << std::endl;
 		}
 	}
 

--- a/extlibs/gameswf/base/tu_gc.h
+++ b/extlibs/gameswf/base/tu_gc.h
@@ -144,7 +144,6 @@ namespace tu_gc {
 		// TODO: are arrays worth implementing?
 		static void* operator new[](size_t sz) {
 			assert(0);
-			return 0;
 		}
 	};
 

--- a/extlibs/gameswf/base/tu_types.cpp
+++ b/extlibs/gameswf/base/tu_types.cpp
@@ -29,7 +29,7 @@ bool	tu_types_validate()
 	}
 
 	// Endian checks.
-	char* buf = "1234";
+	const char* buf = "1234";
 
 #ifdef _TU_LITTLE_ENDIAN_
 	if (*(Uint32*) buf != 0x34333231)

--- a/extlibs/gameswf/base/utility.cpp
+++ b/extlibs/gameswf/base/utility.cpp
@@ -8,20 +8,6 @@
 #include "base/utility.h"
 #include "base/dlmalloc.h"
 
-#ifdef _WIN32
-#ifndef NDEBUG
-
-int	tu_testbed_assert_break(const char* filename, int linenum, const char* expression)
-{
-	// @@ TODO output print error message
-	__asm { int 3 }
-	return 0;
-}
-
-#endif // not NDEBUG
-#endif // _WIN32
-
-
 #ifdef USE_DL_MALLOC
 
 // Overrides of new/delete that use Doug Lea's malloc.  Very helpful

--- a/extlibs/gameswf/base/utility.h
+++ b/extlibs/gameswf/base/utility.h
@@ -16,37 +16,20 @@
 #include "base/tu_swap.h"
 #include <ctype.h>
 #include <new>
+#include <iostream>
 
 
 #ifdef _WIN32
-
-#define __PRETTY_FUNCTION__ __FUNCDNAME__
-#define snprintf _snprintf
-#define strncasecmp _strnicmp
-
-#ifdef SVN_RELEASE
-
-	// It will help users to send messages about bugs
-	#undef assert
-	#define assert(x)		\
+#ifdef NDEBUG
+// It will help users to send messages about bugs
+#undef assert
+#define assert(x)		\
 	if (!(x))		\
-	{		\
-		printf("assert(%s): %s\n%s(%d)\n",  #x, __PRETTY_FUNCTION__, __FILE__, __LINE__);		\
-		exit(0);		\
-	}
-
-#else
-
-	#ifndef NDEBUG
-
-	// On windows, replace ANSI assert with our own, for a less annoying
-	// debugging experience.
-	//int	tu_testbed_assert_break(const char* filename, int linenum, const char* expression);
-	#undef assert
-	#define assert(x)	if (!(x)) { __asm { int 3 } }	// tu_testbed_assert_break(__FILE__, __LINE__, #x))
-
-	#endif // not NDEBUG
-#endif	// not RELEASE
+{		\
+	std::cerr << "assert(" << #x << "): " << __PRETTY_FUNCTION__ << std::endl << __FILE__ << "(" << __LINE__ << ")" << std::endl; \
+	exit(0);		\
+}
+#endif
 #endif // _WIN32
 
 

--- a/extlibs/gameswf/gameswf/gameswf_as_classes/as_sound.cpp
+++ b/extlibs/gameswf/gameswf/gameswf_as_classes/as_sound.cpp
@@ -19,11 +19,10 @@ namespace gameswf
 			as_sound*	snd = cast_to<as_sound>(fn.this_ptr);
 			if (snd)
 			{
-				int offset = 0;
 				int loops = 0;
 				if (fn.nargs >= 2)
 				{
-					offset = fn.arg(0).to_int();
+					fn.arg(0).to_int(); // int offset, unsupported
 					loops = fn.arg(1).to_int();
 				}
 				s->play_sound(snd, snd->m_id, loops);

--- a/extlibs/gameswf/gameswf/gameswf_button.cpp
+++ b/extlibs/gameswf/gameswf/gameswf_button.cpp
@@ -655,7 +655,7 @@ namespace gameswf
 		m_actions.resize(0);
 	}
 
-	button_action &button_action::operator=( const button_action &c )
+	void button_action::operator=( const button_action &c )
 	{
 		m_conditions = c.m_conditions;
 

--- a/extlibs/gameswf/gameswf/gameswf_button.h
+++ b/extlibs/gameswf/gameswf/gameswf_button.h
@@ -66,7 +66,7 @@ namespace gameswf
 		button_action( const button_action &c );
 		~button_action();
 
-		button_action &operator=( const button_action &c );
+		void operator=( const button_action &c );
 
 		void	read(stream* in, int tag_type);
 	};

--- a/extlibs/gameswf/gameswf/gameswf_freetype.cpp
+++ b/extlibs/gameswf/gameswf/gameswf_freetype.cpp
@@ -303,8 +303,8 @@ namespace gameswf
 	image::alpha* glyph_freetype_provider::draw_bitmap(const FT_Bitmap& bitmap)
 	{
 		// You must use power-of-two dimensions!!
-		int	w = 1; while (w < bitmap.width) { w <<= 1; }
-		int	h = 1; while (h < bitmap.rows) { h <<= 1; }
+		int	w = 1; while (w < (int)bitmap.width) { w <<= 1; }
+		int	h = 1; while (h < (int)bitmap.rows) { h <<= 1; }
 
 		image::alpha* alpha = image::create_alpha(w, h);
 		memset(alpha->m_data, 0,  w * h);
@@ -332,11 +332,11 @@ namespace gameswf
 		// 8bpp is the most common and simplest case, hence a separate loop
 		if (bpp==8)
 		{
-			for (int j = 0; j < bitmap.rows; ++j)
+			for (int j = 0; j < (int)bitmap.rows; ++j)
 			{
 				Uint8* dst = alpha->m_data + j * w;
 				const Uint8* src = bitmap.buffer + j * bitmap.pitch;
-				for (int i = 0; i < bitmap.width; ++i)
+				for (int i = 0; i < (int)bitmap.width; ++i)
 				{
 					*dst++ = *src++;
 				}
@@ -346,12 +346,12 @@ namespace gameswf
 			Uint8 mask = 0xff >> (8 - bpp);
 			Uint8 multiplier = 255 / ((1 << bpp) - 1);
 
-			for (int j = 0; j < bitmap.rows; ++j)
+			for (int j = 0; j < (int)bitmap.rows; ++j)
 			{
 				Uint8* dst = alpha->m_data + j * w;
 				const Uint8* src = bitmap.buffer + j * bitmap.pitch;
 				int shift = 8 - bpp;
-				for (int i = 0; i < bitmap.width; ++i)
+				for (int i = 0; i < (int)bitmap.width; ++i)
 				{
 					// since w and h have a good chance of getting larger than the bitmaps height and/or width
 					unsigned char csrc = (((*src) >> shift) & mask) * multiplier;

--- a/extlibs/gameswf/gameswf/gameswf_impl.cpp
+++ b/extlibs/gameswf/gameswf/gameswf_impl.cpp
@@ -1299,9 +1299,6 @@ namespace gameswf
 				bool	has_char = in->read_uint(1) ? true : false;
 				bool	flag_move = in->read_uint(1) ? true : false;
 
-				bool	has_image = false;
-				bool	has_class_name = false;
-				bool	has_cache_asbitmap = false;
 				bool	has_blend_mode = false;
 				bool	has_filter_list = false;
 
@@ -1309,9 +1306,9 @@ namespace gameswf
 				{
 					in->read_uint(3); // unused
 
-					has_image = in->read_uint(1) ? true : false;
-					has_class_name = in->read_uint(1) ? true : false;
-					has_cache_asbitmap = in->read_uint(1) ? true : false;
+					in->read_uint(1); // has_image
+					in->read_uint(1); // has_class_name
+					in->read_uint(1); // has_cache_asbitmap
 					has_blend_mode = in->read_uint(1) ? true : false;
 					has_filter_list = in->read_uint(1) ? true : false;
 				}
@@ -1941,10 +1938,9 @@ namespace gameswf
 		bool sample_16bit = in->read_uint(1) ? true : false;
 		bool stereo = in->read_uint(1) ? true : false;
 		int	sample_count = in->read_u16();
-		int  latency_seek = 0;
 		if (format == sound_handler::FORMAT_MP3)
 		{
-			latency_seek = in->read_s16();
+			in->read_s16(); // int latency_seek
 		}
 
 		IF_VERBOSE_PARSE(log_msg("define stream sound: format=%d, rate=%d, 16=%d, stereo=%d, ct=%d\n", int(format), sample_rate, int(sample_16bit), int(stereo), sample_count));
@@ -1976,12 +1972,10 @@ namespace gameswf
 			m->m_ss_start = m->get_loading_frame();
 		}
 
-		int sample_count = 0;
-		int seek_samples = 0;
 		if (m->m_ss_format == sound_handler::FORMAT_MP3)	//MP3
 		{
-			sample_count = in->read_u16();
-			seek_samples = in->read_s16();
+			in->read_u16(); // int sample_count
+			in->read_s16(); // int seek_samples
 		}
 
 		int data_size = in->get_tag_end_position() - in->get_position();

--- a/extlibs/gameswf/gameswf/gameswf_log.cpp
+++ b/extlibs/gameswf/gameswf/gameswf_log.cpp
@@ -11,6 +11,7 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+#include <iostream>
 
 
 namespace gameswf
@@ -20,12 +21,12 @@ namespace gameswf
 	{
 		if (error)
 		{
-			fprintf(stderr, message);
+			std::cerr << message << std::endl;
 		}
 		else
 		{
 			// NORMAL or VERBOSE
-			printf(message);
+			std::cout << message << std::endl;
 		}
 	}
 

--- a/extlibs/gameswf/gameswf/gameswf_render_handler_ogl.cpp
+++ b/extlibs/gameswf/gameswf/gameswf_render_handler_ogl.cpp
@@ -1716,14 +1716,12 @@ void bitmap_info_ogl::layout()
 		m_width = m_suspended_image->m_width;
 		m_height = m_suspended_image->m_height;
 
-		int bpp = 4;
 		int format = GL_RGBA;
 
 		switch (m_suspended_image->m_type)
 		{
 			case image::image_base::RGB:
 			{
-				bpp = 3;
 				format = GL_RGB;
 			}
 
@@ -1736,7 +1734,7 @@ void bitmap_info_ogl::layout()
 				if (w != m_suspended_image->m_width || h != m_suspended_image->m_height)
 				{
 					ffmpeg_resample(
-						bpp, m_suspended_image->m_width, m_suspended_image->m_height,
+						(format == GL_RGB) ? 3 : 4, m_suspended_image->m_width, m_suspended_image->m_height,
 						m_suspended_image->m_pitch, m_suspended_image->m_data, w, h);
 				}
 				else

--- a/extlibs/gameswf/gameswf/gameswf_sound.cpp
+++ b/extlibs/gameswf/gameswf/gameswf_sound.cpp
@@ -171,10 +171,8 @@ namespace gameswf
 			UNUSED(no_multiple);
 			UNUSED(has_envelope);
 			
-			Uint32	in_point = 0;
-			Uint32	out_point = 0;
-			if (has_in_point) { in_point = in->read_u32(); }
-			if (has_out_point) { out_point = in->read_u32(); }
+			if (has_in_point) { in->read_u32(); }
+			if (has_out_point) { in->read_u32(); }
 			if (has_loops) { m_loop_count = in->read_u16(); }
 			if (has_envelope) 
 			{ 

--- a/extlibs/gameswf/gameswf/gameswf_text.cpp
+++ b/extlibs/gameswf/gameswf/gameswf_text.cpp
@@ -1038,7 +1038,7 @@ namespace gameswf
 	{ 
 		if (get_visible() == false) 
 		{ 
-			return NULL; 
+			return false;
 		} 
 
 		const matrix&  m = get_matrix();

--- a/extlibs/squirrel/squirrel/sqvm.cpp
+++ b/extlibs/squirrel/squirrel/sqvm.cpp
@@ -1077,6 +1077,7 @@ exception_trap:
 		return false;
 	}
 	assert(0);
+	return false; // for stupid compilers
 }
 
 bool SQVM::CreateClassInstance(SQClass *theclass, SQObjectPtr &inst, SQObjectPtr &constructor)

--- a/src/fe_util.cpp
+++ b/src/fe_util.cpp
@@ -900,7 +900,8 @@ bool run_program( const std::string &prog,
 		{
 			size_t pos = prog.find_last_of( "/" );
 			if ( pos != std::string::npos )
-				chdir( prog.substr( 0, pos ).c_str() );
+				if (chdir( prog.substr( 0, pos ).c_str() ) != 0)
+					std::cerr << "Warning, chdir(" << prog.substr( 0, pos ) << ") failed.";
 		}
 		execvp( prog.c_str(), arg_list );
 

--- a/util/osx/create-pkg.sh
+++ b/util/osx/create-pkg.sh
@@ -45,7 +45,7 @@ if [[ "$PLATFORM" != "Darwin" ]]; then
 	[[ -z ${TOOLCHAIN} ]] && export TOOLCHAIN=x86_64-apple-${OSXCROSS_TARGET}
 	[[ -z ${LIB_BASE_PATH} ]] && export LIB_BASE_PATH="$(realpath ${OSXCROSS_TARGET_DIR}/macports/pkgs)"
 
-	MAKEOPTS="$MAKEOPTS CC=clang CXX=clang++ AR=libtool ARFLAGS=\"-static -o\" CROSS=1 TOOLCHAIN=${TOOLCHAIN} FE_MACOSX_COMPILE=1 EXTRA_CFLAGS=\"-arch i386 -arch x86_64\""
+	MAKEOPTS="$MAKEOPTS CC=clang CXX=clang++ AR=libtool ARFLAGS=\"-static -o\" CROSS=1 TOOLCHAIN=${TOOLCHAIN} FE_MACOSX_COMPILE=1"
 fi
 
 NPROC=$(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
* libarchive pkg-config includes zlib automatically, but fails on OSX
  when using system provided lib (no pkg-config support).
* change LIBS and CFLAGS to simple variables so shell is not executed
  for every obj compiled.
* remove EXTRA_CFLAGS from osx build script so builder can specify arch