### PR TITLE
Cools: Fix off-by-one error in ToNewList transition

### DIFF
--- a/config/layouts/Cools/layout.nut
+++ b/config/layouts/Cools/layout.nut
@@ -168,6 +168,7 @@ fe.add_transition_callback( "fade_transitions" );
 function fade_transitions( ttype, var, ttime ) {
  switch ( ttype ) {
   case Transition.ToNewList:
+   var = 0;
   case Transition.ToNewSelection:
    gametitleshadow.msg = gamename ( var );
    gametitle.msg = gametitleshadow.msg;


### PR DESCRIPTION
When switching between lists in the Cools layout, the game name and copyright text were mismatched with the actual selected game, always showing text for the previous or next game depending on the direction on the transition.