### PR TITLE
Restore movie volume setting in post-run

### DIFF
--- a/src/fe_present.cpp
+++ b/src/fe_present.cpp
@@ -1128,6 +1128,10 @@ void FePresent::post_run()
 		(*its)->release_audio( false );
 #endif
 
+	for ( std::vector<FeBaseTextureContainer *>::iterator itm=m_texturePool.begin();
+				itm != m_texturePool.end(); ++itm )
+		(*itm)->set_vol( m_feSettings->get_play_volume( FeSoundInfo::Movie ) );
+
 	set_video_play_state( m_playMovies );
 	on_transition( FromGame, FromToNoValue );
 


### PR DESCRIPTION
After returning from a game, the movie played at a volume of 100 regardless of the movie volume setting.