### PR TITLE
Changes to Debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,17 @@ Source: attract
 Section: games
 Priority: optional
 Maintainer: Andrew Mickelson <andrew@attractmode.org>
-Build-Depends: debhelper (>= 9), pkgconf, libsfml-dev, libfreetype6-dev, libavutil-dev, libavcodec-dev, libavformat-dev, libavresample-dev, libswscale-dev, libfontconfig-dev, libopenal-dev, libjpeg62-turbo-dev, libarchive-dev, libxinerama-dev
+Build-Depends: debhelper (>= 9), pkgconf, git,
+ libarchive-dev, libavcodec-dev, libavformat-dev, libavresample-dev,
+ libavutil-dev, libfontconfig-dev, libfreetype6-dev, libglu-dev,
+ libjpeg62-turbo-dev | libjpeg-turbo8-dev,
+ libopenal-dev, libsfml-dev, libswscale-dev, libxinerama-dev
 Standards-Version: 3.9.5
 Homepage: http://attractmode.org
 
 Package: attract
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libsfml-graphics2, libsfml-network2, libsfml-system2, libsfml-window2, libavutil54, libavcodec56, libavformat56, libavresample2, libswscale3, libfontconfig1, libarchive13, libxinerama1
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Attract-Mode emulator frontend
  Attract-Mode is a graphical frontend for command line emulators such as MAME,
  MESS and Nestopia. It hides the underlying operating system and is intended

--- a/debian/rules
+++ b/debian/rules
@@ -28,7 +28,7 @@ override_dh_auto_build:
 	dh_auto_build -- prefix="/usr"
 
 override_dh_auto_install:
-	dh_auto_install -- prefix="/usr" bindir="/usr/games"
+	@
 
 # debmake generated override targets
 # This is example for Cmake (See http://bugs.debian.org/641051 )


### PR DESCRIPTION
The changes in this PR are things I had to change to get successful builds of the `attract` package on my [Ubuntu PPA](https://launchpad.net/~daveg/+archive/ubuntu/attract)

- Add a build depend of `libjpeg62-turbo-dev` or `libjpeg-turbo8-dev` since `libjpeg62-turbo-dev` isn't available on most releases of Ubuntu
- Remove explicit install depends as the build process adds these anyhow using the `${shlib:Depends}` macro and making the version explicit causes issues when building for different versions of Debian and Ubuntu:
Here's the automatically generated list of depends for Ubuntu 14.04:
```
Depends: libarchive13, libavcodec54 (>= 6:9.1-1) | libavcodec-extra-54 (>= 6:9.18), libavformat54 (>= 6:9.1-1), libavresample1 (>= 6:9.1-1), libavutil52 (>= 6:9.1-1), libc6 (>= 2.14),
         libexpat1 (>= 2.0.1), libfontconfig1 (>= 2.9.0), libfreetype6 (>= 2.2.1), libgcc1 (>= 1:4.1.1), libgl1-mesa-glx | libgl1, libjpeg8 (>= 8c), libopenal1 (>= 1:1.13), libsfml-graphics2
         (>= 2.1), libsfml-network2 (>= 2.1), libsfml-system2 (>= 2.1), libsfml-window2 (>= 2.1), libstdc++6 (>= 4.6), libswscale2 (>= 6:9.1-1), libx11-6, libxinerama1, zlib1g (>= 1:1.1.4)

```
And here's the list for Ubuntu 16.04:
```
Depends: libarchive13, libavcodec-ffmpeg56 (>= 7:2.4) | libavcodec-ffmpeg-extra56 (>= 7:2.4), libavformat-ffmpeg56 (>= 7:2.4), libavutil-ffmpeg54 (>= 7:2.4), libc6 (>= 2.14), libexpat1 (>=
         2.0.1), libfontconfig1 (>= 2.11.94), libfreetype6 (>= 2.2.1), libgcc1 (>= 1:3.0), libgl1-mesa-glx | libgl1, libjpeg8 (>= 8c), libopenal1 (>= 1.14), libsfml-graphics2.3v5 (>= 2.3),
         libsfml-network2.3v5 (>= 2.3), libsfml-system2.3v5 (>= 2.3), libsfml-window2.3v5 (>= 2.3), libstdc++6 (>= 5.2), libswresample-ffmpeg1 (>= 7:2.4), libswscale-ffmpeg3 (>= 7:2.4),
         libx11-6, libxinerama1, zlib1g (>= 1:1.1.4)

```
- Change `override_dh_auto_install` as the current way of doing it was causing build issues on Ubuntu Trusty (it wouldn't create the directory `usr/games` so installing the `attract` binary would fail). Setting this to just `@` is shorthand for packaging what's defined in `debian/install` which is what we want.

If you're curious to see what the resulting packaging looks like, here's the package build logs:
* [Ubuntu Trusty](https://launchpad.net/~daveg/+archive/ubuntu/attract/+build/10028969/+files/buildlog_ubuntu-trusty-amd64.attract_2.1.0-4+trusty0_BUILDING.txt.gz)
* [Ubuntu Wily](https://launchpad.net/~daveg/+archive/ubuntu/attract/+build/10041936/+files/buildlog_ubuntu-wily-amd64.attract_2.1.0-4+wily0_BUILDING.txt.gz)
* [Ubuntu Xenial](https://launchpad.net/~daveg/+archive/ubuntu/attract/+build/10041932/+files/buildlog_ubuntu-xenial-amd64.attract_2.1.0-4+xenial0_BUILDING.txt.gz)
* [Ubuntu Yakkaty](https://launchpad.net/~daveg/+archive/ubuntu/attract/+build/10041934/+files/buildlog_ubuntu-yakkety-amd64.attract_2.1.0-4+yakkety0_BUILDING.txt.gz)
