### PR TITLE
[linux] Added appdata file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+attract (2.2.1-2) unstable; urgency=low
+
+  * Install appdata file.
+
 attract (2.2.1-1) unstable; urgency=low
 
   * Version 2.2.1 package.

--- a/debian/install
+++ b/debian/install
@@ -2,3 +2,4 @@ attract /usr/games
 config/* /usr/share/attract
 util/linux/attract-mode.png /usr/share/icons/hicolor/512x512/apps
 util/linux/attract-mode.desktop /usr/share/applications
+util/linux/attract-mode.appdata.xml /usr/share/appdata

--- a/util/linux/attract-mode.appdata.xml
+++ b/util/linux/attract-mode.appdata.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>attract-mode.desktop</id>
+  <metadata_license>CC0</metadata_license>
+  <project_license>GPL-3.0+</project_license>
+  <name>Attract-Mode</name>
+  <summary>A graphical frontend for emulators</summary>
+
+  <description>
+    <p>
+      Attract-Mode is a graphical frontend for command line emulators such as MAME,
+      MESS and Nestopia. It hides the underlying operating system and is intended to
+      be controlled with a joystick, gamepad or spinner, making it ideal for use
+      in arcade cabinets.
+    </p>
+  </description>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>http://attractmode.org/images/cools1.png</image>
+    </screenshot>
+    <screenshot>
+      <image>http://attractmode.org/images/attracman.png</image>
+    </screenshot>
+    <screenshot>
+      <image>http://attractmode.org/images/cools2.png</image>
+    </screenshot>
+    <screenshot>
+      <image>http://attractmode.org/images/config.png</image>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">http://attractmode.org/</url>
+
+  <provides>
+    <binary>attract</binary>
+  </provides>
+  <categories>
+    <category>Game</category>
+    <category>Emulator</category>
+  </categories>
+</component>

--- a/util/linux/attract-mode.desktop
+++ b/util/linux/attract-mode.desktop
@@ -2,8 +2,8 @@
 Version=1.0
 Name=Attract-Mode
 Comment=Emulator Frontend
-Exec=/usr/games/attract
+Exec=attract
 Terminal=false
 Type=Application
-Categories=Game
+Categories=Game;Emulator;
 Icon=attract-mode


### PR DESCRIPTION
Added an appdata file, it is a cross-distribution standard which adds metadata for Linux software stores.
See also https://people.freedesktop.org/%7Ehughsient/appdata/ for reference.

E.g. for openSUSE packages with appdata files are listed here: https://software.opensuse.org/packages/Games

I also slightly modified the .desktop file, I changed the exec to be independent from installation path (e.g. `/usr/bin`, `/usr/games` ...).
Also `Categories` should end with a trailing semicolon.