### PR TITLE
Makefile: Fix install target for mac and some linux distros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,6 @@ ifneq ($(FE_DEBUG),1)
 endif
 
 .PHONY: clean
-
 .PHONY: install
 
 $(OBJ_DIR):
@@ -677,10 +676,9 @@ $(DATA_PATH):
 	$(MD) -p $(DESTDIR)$@
 
 install: $(EXE) $(DATA_PATH)
-	install -D -t $(DESTDIR)$(bindir) $(EXE)
+	install -D $(EXE) $(DESTDIR)$(bindir)/$(EXE)
 	mkdir -p $(DESTDIR)$(DATA_PATH)
 	cp -r config/* $(DESTDIR)$(DATA_PATH)
-
 
 smallclean:
 	-$(RM) $(OBJ_DIR)/*.o *~ core


### PR DESCRIPTION
On mac (sierra) the install target fails because `-t` is unknown.

```install: illegal option -- t
usage: install [-bCcpSsv] [-B suffix] [-f flags] [-g group] [-m mode]
               [-o owner] file1 file2
       install [-bCcpSsv] [-B suffix] [-f flags] [-g group] [-m mode]
               [-o owner] file1 ... fileN directory
       install -d [-v] [-g group] [-m mode] [-o owner] directory ...
make: *** [install] Error 64
```

Also on some Linux distributions install does not support `-D` and `-t` to be combined.