### PR TITLE
Extlibs: Fixed nonvoid function without return value in gameswf

### DIFF
--- a/extlibs/gameswf/base/tu_gc.h
+++ b/extlibs/gameswf/base/tu_gc.h
@@ -144,6 +144,7 @@ namespace tu_gc {
 		// TODO: are arrays worth implementing?
 		static void* operator new[](size_t sz) {
 			assert(0);
+			return NULL;
 		}
 	};
 


### PR DESCRIPTION
When compiling on openSUSE I got an error from the buildsystem (OBS + RPMLint):

```
 I: Program returns random data in a function
 E: attractmode no-return-in-nonvoid-function extlibs/gameswf/base/tu_gc.h:146
```

This is a very simple patch, not sure if this error occurs also on other buildsystems.