### PR TITLE
Fix slow downward trackball movement responsiveness

### DIFF
--- a/src/fe_input.cpp
+++ b/src/fe_input.cpp
@@ -281,12 +281,12 @@ FeInputSingle::FeInputSingle( const sf::Event &e, const sf::IntRect &mc_rect, co
 				m_type = Mouse;
 				m_code = MouseUp;
 			}
-			else if ( e.mouseMove.x > mc_rect.left + mc_rect.width )
+			else if ( e.mouseMove.x >= mc_rect.left + mc_rect.width )
 			{
 				m_type = Mouse;
 				m_code = MouseRight;
 			}
-			else if ( e.mouseMove.y > mc_rect.top + mc_rect.height )
+			else if ( e.mouseMove.y >= mc_rect.top + mc_rect.height )
 			{
 				m_type = Mouse;
 				m_code = MouseDown;


### PR DESCRIPTION
If you move the mouse downward very slowly, the wheel won't move.   Turning on the mouse cursor, you can see this is because the mouse pointer position will reset to center at the moment that the mouse pointer leaves the bounding box.    So you can keep scrolling slowly but indefinitely, and it will reset to the center position without ever passing the hit downward or right hit test that moves the wheel.

The upward and left movements do not have this issue. 

By changing these checks to be >= instead of >, it hits properly and moves symmetrically with the up or left scrolling.   The end result feels much more precise. 

