### PR TITLE
fe.Text improvements

### DIFF
--- a/src/fe_text.cpp
+++ b/src/fe_text.cpp
@@ -36,7 +36,8 @@ FeText::FeText( FePresentableParent &p, const std::string &str,
 	m_user_charsize( -1 ),
 	m_size( w, h ),
 	m_position( x, y ),
-	m_scale_factor( 1.0 )
+	m_scale_factor( 1.0 ),
+	m_no_margin( 0 )
 {
 }
 
@@ -173,6 +174,17 @@ void FeText::set_word_wrap( bool w )
 bool FeText::get_word_wrap()
 {
 	return ( m_draw_text.getFirstLineHint() >= 0 );
+}
+
+void FeText::set_no_margin( bool m )
+{
+	m_draw_text.setNoMargin( m );
+	FePresent::script_do_update( this );
+}
+
+bool FeText::get_no_margin()
+{
+	return m_draw_text.getNoMargin();
 }
 
 void FeText::set_first_line_hint( int l )

--- a/src/fe_text.hpp
+++ b/src/fe_text.hpp
@@ -66,6 +66,9 @@ public:
 	void set_word_wrap( bool );
 	bool get_word_wrap();
 
+	void set_no_margin( bool );
+	bool get_no_margin();
+
 	void set_first_line_hint( int l );
 	int get_first_line_hint();
 
@@ -108,6 +111,7 @@ private:
 	sf::Vector2f m_size;		// unscaled size
 	sf::Vector2f m_position;	// unscaled position
 	float m_scale_factor;
+    bool m_no_margin;
 };
 
 #endif

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -672,6 +672,7 @@ bool FeVM::on_new_layout()
 		.Prop(_SC("first_line_hint"), &FeText::get_first_line_hint, &FeText::set_first_line_hint )
 		.Prop(_SC("msg_width"), &FeText::get_actual_width )
 		.Prop(_SC("font"), &FeText::get_font, &FeText::set_font )
+		.Prop(_SC("nomargin"), &FeText::get_no_margin, &FeText::set_no_margin )
 		.Func( _SC("set_bg_rgb"), &FeText::set_bg_rgb )
 	);
 

--- a/src/tp.cpp
+++ b/src/tp.cpp
@@ -29,7 +29,7 @@ FeTextPrimative::FeTextPrimative( )
 	m_align( Centre ),
 	m_first_line( -1 ),
 	m_needs_pos_set( false ),
-    m_no_margin( 0 )
+	m_no_margin( 0 )
 {
 	setColor( sf::Color::White );
 	setBgColor( sf::Color::Transparent );
@@ -45,7 +45,7 @@ FeTextPrimative::FeTextPrimative(
 	m_align( align ),
 	m_first_line( -1 ),
 	m_needs_pos_set( false ),
-    m_no_margin( 0 )
+	m_no_margin( 0 )
 {
 	if ( font )
 		setFont( *font );
@@ -61,7 +61,7 @@ FeTextPrimative::FeTextPrimative( const FeTextPrimative &c )
 	m_align( c.m_align ),
 	m_first_line( c.m_first_line ),
 	m_needs_pos_set( c.m_needs_pos_set ),
-    m_no_margin( c.m_no_margin )
+	m_no_margin( c.m_no_margin )
 {
 }
 

--- a/src/tp.cpp
+++ b/src/tp.cpp
@@ -268,7 +268,7 @@ void FeTextPrimative::set_positions() const
 		textSize.height *= m_texts[i].getScale().y;
 
 		textPos.y = rectPos.y
-				+ floorf( spacing * i
+				+ ceilf( spacing * i
 				+ ( rectSize.height - ( spacing * m_texts.size() )) / 2);
 
 		// set x position

--- a/src/tp.cpp
+++ b/src/tp.cpp
@@ -22,12 +22,14 @@
 
 #include "tp.hpp"
 #include <iostream>
+#include <cmath>
 
 FeTextPrimative::FeTextPrimative( )
 	: m_texts( 1, sf::Text() ),
 	m_align( Centre ),
 	m_first_line( -1 ),
-	m_needs_pos_set( false )
+	m_needs_pos_set( false ),
+    m_no_margin( 0 )
 {
 	setColor( sf::Color::White );
 	setBgColor( sf::Color::Transparent );
@@ -42,7 +44,8 @@ FeTextPrimative::FeTextPrimative(
 	: m_texts( 1, sf::Text() ),
 	m_align( align ),
 	m_first_line( -1 ),
-	m_needs_pos_set( false )
+	m_needs_pos_set( false ),
+    m_no_margin( 0 )
 {
 	if ( font )
 		setFont( *font );
@@ -57,7 +60,8 @@ FeTextPrimative::FeTextPrimative( const FeTextPrimative &c )
 	m_texts( c.m_texts ),
 	m_align( c.m_align ),
 	m_first_line( c.m_first_line ),
-	m_needs_pos_set( c.m_needs_pos_set )
+	m_needs_pos_set( c.m_needs_pos_set ),
+    m_no_margin( c.m_no_margin )
 {
 }
 
@@ -264,14 +268,15 @@ void FeTextPrimative::set_positions() const
 		textSize.height *= m_texts[i].getScale().y;
 
 		textPos.y = rectPos.y
-				+ spacing * i
-				+ ( rectSize.height - ( spacing * m_texts.size() )) / 2;
+				+ floorf( spacing * i
+				+ ( rectSize.height - ( spacing * m_texts.size() )) / 2);
 
 		// set x position
 		switch ( m_align )
 		{
 		case Left:
-			textPos.x = rectPos.x + spacing/2;
+			if( m_no_margin ) textPos.x = rectPos.x;
+			else textPos.x = rectPos.x + ( spacing/2 );
 			break;
 
 		case Centre:
@@ -279,7 +284,8 @@ void FeTextPrimative::set_positions() const
 			break;
 
 		case Right:
-			textPos.x = rectPos.x + rectSize.width - textSize.width - spacing/2;
+			if( m_no_margin ) textPos.x = rectPos.x + rectSize.width - textSize.width;
+			else textPos.x = rectPos.x + rectSize.width - textSize.width - ( spacing/2 );
 			break;
 		}
 
@@ -407,6 +413,16 @@ void FeTextPrimative::setFirstLineHint( int line )
 void FeTextPrimative::setWordWrap( bool wrap )
 {
 	m_first_line = wrap ? 0 : -1;
+}
+
+void FeTextPrimative::setNoMargin( bool margin )
+{
+	m_no_margin = margin;
+}
+
+bool FeTextPrimative::getNoMargin()
+{
+	return m_no_margin;
 }
 
 void FeTextPrimative::setTextScale( const sf::Vector2f &s )

--- a/src/tp.cpp
+++ b/src/tp.cpp
@@ -261,7 +261,7 @@ void FeTextPrimative::set_positions() const
 	for ( unsigned int i=0; i < m_texts.size(); i++ )
 	{
 		sf::Vector2f textPos;
-
+		
 		// we need to account for the scaling that we have applied to our text...
 		sf::FloatRect textSize = m_texts[i].getLocalBounds();
 		textSize.width *= m_texts[i].getScale().x;
@@ -276,16 +276,16 @@ void FeTextPrimative::set_positions() const
 		{
 		case Left:
 			if( m_no_margin ) textPos.x = rectPos.x;
-			else textPos.x = rectPos.x + ( spacing/2 );
+			else textPos.x = rectPos.x + floorf( spacing/2 );
 			break;
 
 		case Centre:
-			textPos.x = rectPos.x + ( (rectSize.width - textSize.width) / 2 );
+			textPos.x = rectPos.x + floorf( (rectSize.width - textSize.width) / 2 );
 			break;
 
 		case Right:
 			if( m_no_margin ) textPos.x = rectPos.x + rectSize.width - textSize.width;
-			else textPos.x = rectPos.x + rectSize.width - textSize.width - ( spacing/2 );
+			else textPos.x = rectPos.x + rectSize.width - textSize.width - floorf( spacing/2 );
 			break;
 		}
 

--- a/src/tp.hpp
+++ b/src/tp.hpp
@@ -73,6 +73,8 @@ public:
 	void setOutlineThickness( int );
 	void setFirstLineHint( int );
 	void setWordWrap( bool );
+	void setNoMargin( bool );
+	bool getNoMargin();
 	void setTextScale( const sf::Vector2f & );
 
 	const sf::Font *getFont() const;
@@ -100,6 +102,7 @@ private:
 	// to control scrolling text where the text set into the control is
 	// larger than the area available to display it.
 	int m_first_line;
+	bool m_no_margin;
 
 	mutable bool m_needs_pos_set;
 


### PR DESCRIPTION
Fixed vertical alignment of fonts, so thin fonts are snapping to pixels and do not appear blury
It does not affect the subpixel vertical scrolling.
Added "nomargin" property to fe.Text so the font can be aligned using textbox coordinates.