### PR TITLE
Add $PROGDIR variable/expansion for substituting program directory in path leadings

### DIFF
--- a/config/language/cn.msg
+++ b/config/language/cn.msg
@@ -343,7 +343,7 @@ _help_displays_menu_prompt;The 'Displays Menu' prompt (i.e. "Select System")
 _help_emu_add;Add a new emulator
 _help_emu_args;The command line arguments for this emulator.  The following get substituted appropriately: [name], [romext], [rompath], [emulator], [romfilename], [system], [systemn], [workdir], [nothing]
 _help_emu_delete;Delete the entry for this emulator
-_help_emu_executable;The full path and name of the emulator executable. $HOME gets replaced with the user's home dir
+_help_emu_executable;The full path and name of the emulator executable. Possible variables: $HOME = User's home dir; $PROGDIR = Attract-Mode program dir; Windows OS additionally have %SYSTEMROOT% and %PROGRAMFILES% matching system environment variables.
 _help_emu_exit_hotkey;Set a global hotkey to exit the emulator.  Attract-Mode will terminate the emulator process if this hotkey gets pressed
 _help_emu_gen_romlist;Generate a romlist by searching the configured rom path for roms with the configured extension, incorporating XML and additional import file information into the generated list (if available)
 _help_emu_import_extras;Path to any additional files that need to be read when generating a romlist for this emulator.  Supported files are: catver.ini (for game categories), nplayers.ini (for number of players) and mame.xml.  Multiple file paths can be entered if separated by a semicolon

--- a/config/language/en.msg
+++ b/config/language/en.msg
@@ -78,7 +78,7 @@ _help_displays_menu_prompt;The 'Displays Menu' prompt (i.e. "Select System")
 _help_emu_add;Add a new emulator
 _help_emu_args;The command line arguments for this emulator.  The following get substituted appropriately: [name], [romext], [rompath], [emulator], [romfilename], [system], [systemn], [workdir], [nothing]
 _help_emu_delete;Delete the entry for this emulator
-_help_emu_executable;The full path and name of the emulator executable. $HOME gets replaced with the user's home dir
+_help_emu_executable;The full path and name of the emulator executable. Possible variables: $HOME = User's home dir; $PROGDIR = Attract-Mode program dir; Windows OS additionally have %SYSTEMROOT% and %PROGRAMFILES% matching system environment variables.
 _help_emu_exit_hotkey;Set a global hotkey to exit the emulator.  Attract-Mode will terminate the emulator process if this hotkey gets pressed
 _help_emu_gen_romlist;Generate a romlist by searching the configured rom path for roms with the configured extension, incorporating XML and additional import file information into the generated list (if available)
 _help_emu_import_extras;Path to any additional files that need to be read when generating a romlist for this emulator.  Supported files are: catver.ini (for game categories), nplayers.ini (for number of players) and mame.xml.  Multiple file paths can be entered if separated by a semicolon

--- a/config/language/msg_template.txt
+++ b/config/language/msg_template.txt
@@ -300,7 +300,7 @@ _help_displays_menu_prompt;The 'Displays Menu' prompt (i.e. "Select System")
 _help_emu_add;Add a new emulator
 _help_emu_args;The command line arguments for this emulator.  The following get substituted appropriately: [name], [romext], [rompath], [emulator], [romfilename], [system], [systemn], [workdir], [nothing]
 _help_emu_delete;Delete the entry for this emulator
-_help_emu_executable;The full path and name of the emulator executable. $HOME gets replaced with the user's home dir
+_help_emu_executable;The full path and name of the emulator executable. Possible variables: $HOME = User's home dir; $PROGDIR = Attract-Mode program dir; Windows OS additionally have %SYSTEMROOT% and %PROGRAMFILES% matching system environment variables.
 _help_emu_exit_hotkey;Set a global hotkey to exit the emulator.  Attract-Mode will terminate the emulator process if this hotkey gets pressed
 _help_emu_gen_romlist;Generate a romlist by searching the configured rom path for roms with the configured extension, incorporating XML and additional import file information into the generated list (if available)
 _help_emu_import_extras;Path to any additional files that need to be read when generating a romlist for this emulator.  Supported files are: catver.ini (for game categories), nplayers.ini (for number of players) and mame.xml.  Multiple file paths can be entered if separated by a semicolon

--- a/src/fe_util.cpp
+++ b/src/fe_util.cpp
@@ -241,6 +241,10 @@ std::string clean_path( const std::string &path, bool add_trailing_slash )
 	if (( retval.size() >= 5 ) && ( retval.compare( 0, 5, "$HOME" ) == 0 ))
 		retval.replace( 0, 5, get_home_dir() );
 
+	// substitute program dir for leading $PROGDIR
+	if (( retval.size() >= 8 ) && ( retval.compare( 0, 8, "$PROGDIR" ) == 0 ))
+		retval.replace( 0, 8, get_program_path() );
+
 	if (( add_trailing_slash )
 #ifdef SFML_SYSTEM_WINDOWS
 			&& (retval[retval.size()-1] != '\\')
@@ -249,6 +253,21 @@ std::string clean_path( const std::string &path, bool add_trailing_slash )
 		retval += '/';
 
 	return retval;
+}
+
+std::string get_program_path()
+{
+	std::string path;
+#ifdef SFML_SYSTEM_WINDOWS
+	char result[ MAX_PATH ];
+	path = std::string( result, GetModuleFileName( NULL, result, MAX_PATH ) );
+#else
+	char result[ PATH_MAX ];
+	ssize_t count = readlink( "/proc/self/exe", result, PATH_MAX );
+	path = std::string( result, (count > 0) ? count : 0 );
+#endif
+	size_t found = path.find_last_of("/\\");
+	return( path.substr(0, found) );
 }
 
 std::string absolute_path( const std::string &path )

--- a/src/fe_util.hpp
+++ b/src/fe_util.hpp
@@ -131,6 +131,9 @@ bool is_relative_path( const std::string &file );
 std::string clean_path( const std::string &path,
 	bool add_trailing_slash = false );
 
+// get program path (NOT the working directory)
+std::string get_program_path();
+
 // return path as an absolute path
 std::string absolute_path( const std::string &path );
 


### PR DESCRIPTION
This one is a bit more. Pretty self-explanatory.

I wanted a "portable" setup, and this new variable solves that. Working with relatives paths is impossible when the attract exe and emulator exe are at different directory depths.

Two things of note: I can't test the Linux code (can't compile for some reason) but it's a shameless stackoverflow copy-paste and looks simple/solid enough to me. Works perfectly on Windows. Secondly, language strings would need updating, I added some UX improvement there IMO but do with that as you wish, of course.