### PR TITLE
RPI: update for new vendor library names & add Mesa VC4 override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,8 @@ ifneq ($(NO_SWF),1)
   ifneq ($(FE_MACOSX_COMPILE),1)
    CFLAGS += -Wl,--export-dynamic
    ifeq ($(USE_GLES),1)
-    LIBS += -ldl -lGLESv1_CM
+    GLES_LIB ?= -lGLESv1_CM
+    LIBS += -ldl $(GLES_LIB)
    else
     LIBS += -ldl -lGL
    endif
@@ -308,8 +309,15 @@ ifeq ($(USE_GLES),1)
  #
  # Hack for Raspberry Pi includes...
  #
- ifneq ("$(wildcard /opt/vc/include/bcm_host.h)","")
-  CFLAGS += -I/opt/vc/include -L/opt/vc/lib
+ifneq ($(USE_VC4),1)
+  ifneq ("$(wildcard /opt/vc/include/bcm_host.h)","")
+   CFLAGS += -I/opt/vc/include -L/opt/vc/lib
+   ifneq ("$(wildcard /opt/vc/lib/libbrcmGLESv2.so)","")
+    GLES_LIB := -lbrcmGLESv2
+   else
+    GLES_LIB := -lGLESv2
+   endif
+  endif
  endif
 endif
 


### PR DESCRIPTION
Recent Pi firmwares have renamed the vendor graphics libraries to
help distinguish from Mesa libraries. Update to the new name; this
will fix Raspbian stretch compatibility and will work with recent
jessie firmware packages (1.20160921-1 or later).

Also add an override, USE_VC4=1, to allow targeting Pi builds against
the experimental Mesa VC4 driver.