### PR TITLE
GameSWF C++11 Syntax Fix

### DIFF
--- a/extlibs/gameswf/gameswf/gameswf_player.cpp
+++ b/extlibs/gameswf/gameswf/gameswf_player.cpp
@@ -231,11 +231,10 @@ namespace gameswf
 	const char* get_gameswf_version()
 	{
 #ifdef WIN32
-	static tu_string s_gameswf_version("WIN "__DATE__" "__TIME__);
+	static tu_string s_gameswf_version("WIN " __DATE__ " " __TIME__);
 #else
-	static tu_string s_gameswf_version("LINUX "__DATE__" "__TIME__);
+	static tu_string s_gameswf_version("LINUX " __DATE__ " " __TIME__);
 #endif
-		
 		return s_gameswf_version.c_str();
 	}
 


### PR DESCRIPTION
Fixes the following warnings during compilation:

```
extlibs/gameswf/gameswf/gameswf_player.cpp:236:37: warning: invalid suffix on literal; C++11 requires a space between literal and string macro [-Wliteral-suffix]
  static tu_string s_gameswf_version("LINUX "__DATE__" "__TIME__);
                                     ^
extlibs/gameswf/gameswf/gameswf_player.cpp:236:53: warning: invalid suffix on literal; C++11 requires a space between literal and string macro [-Wliteral-suffix]
  static tu_string s_gameswf_version("LINUX "__DATE__" "__TIME__);
```