### PR TITLE
Issue #401 - Implement proposed changes to zorder behaviour

### DIFF
--- a/Layouts.md
+++ b/Layouts.md
@@ -1461,8 +1461,9 @@ Properties:
      `Transition.EndNavigation`.  Default value is `Transition.ToNewSelection`.
    * `smooth` - Get/set whether the image is to be smoothed.  Default value can
      be configured in attract.cfg
-   * `zorder` - Get/set the Image's order in the applicable draw list.  When
-     objects overlap, the one with the higher zorder will be drawn on top.
+   * `zorder` - Get/set the Image's order in the applicable draw list.  Objects
+     with a lower zorder are drawn first, so that when objects overlap, the one
+     with the higher zorder is drawn on top.  Default value is 0.
 
 Member Functions:
 
@@ -1621,8 +1622,9 @@ Properties:
      the text (boolean).  Default value is `false`.
    * `shader` - Get/set the GLSL shader for this text. This can only be set to
      an instance of the class `fe.Shader` (see: `fe.add_shader()`).
-   * `zorder` - Get/set the Text's order in the applicable draw list.  When
-     objects overlap, the one with the higher zorder will be drawn on top.
+   * `zorder` - Get/set the Text's order in the applicable draw list.  Objects
+     with a lower zorder are drawn first, so that when objects overlap, the one
+     with the higher zorder is drawn on top.  Default value is 0.
 
 Member Functions:
 
@@ -1718,8 +1720,9 @@ Properties:
      behaviour as if set to "[Title]").  Default is an empty value.
    * `shader` - Get/set the GLSL shader for this listbox. This can only be set
      to an instance of the class `fe.Shader` (see: `fe.add_shader()`).
-   * `zorder` - Get/set the Listbox's order in the applicable draw list.  When
-     objects overlap, the one with the higher zorder will be drawn on top.
+   * `zorder` - Get/set the Listbox's order in the applicable draw list.  Objects
+     with a lower zorder are drawn first, so that when objects overlap, the one
+     with the higher zorder is drawn on top.  Default value is 0.
 
 Member Functions:
 

--- a/config/loader/hyperspin.nut
+++ b/config/loader/hyperspin.nut
@@ -118,53 +118,64 @@ for ( local i=0; i< fe.displays.len(); i++ )
 //
 // - background
 // - art1
+// - (video_overlay if overlaybelow=true)
 // - video 
 // - video_overlay
+// - (art1 if below=true)
 // - art2
 // - art3
 // - art4
+// - (wheel)
+// - (prompts)
+// - override transitions
 //
 ::hs_ent.background <- {
 		dir = "Images/Backgrounds/"
 		obj = fe.add_image( "" )
-		zorder = 0
+		zorder = -10
 	};
 
 ::hs_ent.artwork1 <- {
 		dir = "Images/Artwork1/"
 		obj = fe.add_image( "" )
-		zorder = 1
+		zorder = -9
 	};
+
+// zorder -8 - hs_ent.video_overlay zorder goes here if overlaybelow=true
 
 ::hs_ent.video <- {
 		dir = "Video/"
 		obj = fe.add_image( "" )
-		zorder = 2
+		zorder = -7
 	};
 
 ::hs_ent.video_overlay <- {
 		dir = ""
 		obj = fe.add_image( "" )
-		zorder = 3
+		zorder = -6
 	};
+
+// zorder -5 - hs_ent.artwork1 zorder goes here if below=true
 
 ::hs_ent.artwork2 <- {
 		dir = "Images/Artwork2/"
 		obj = fe.add_image( "" )
-		zorder = 4
+		zorder = -4
 	};
 
 ::hs_ent.artwork3 <- {
 		dir = "Images/Artwork3/"
 		obj = fe.add_image( "" )
-		zorder = 5
+		zorder = -3
 	};
 
 ::hs_ent.artwork4 <- {
 		dir = "Images/Artwork4/"
 		obj = fe.add_image( "" )
-		zorder = 6
+		zorder = -2
 	};
+
+// wheel and prompts zorder is at 0
 
 ::hs_ent.override_transition <- {
 		dir = "Video/Override Transitions/"
@@ -519,7 +530,7 @@ function load( ttype, match_map, hs_sys_dir )
 			local d=0.0;
 			local type = "";
 			local start = "";
-			local vid_below=false;
+			local overlay_below=false;
 			local overlayoffsetx = 0;
 			local overlayoffsety = 0;
 
@@ -544,7 +555,7 @@ function load( ttype, match_map, hs_sys_dir )
 					break;
 				case "overlaybelow":
 					if ( v == "true" )
-						vid_below = true;
+						overlay_below = true;
 					break;
 				case "forceaspect":
 					if (( c.tag == "video" ) && ( v == "both" ))
@@ -601,8 +612,8 @@ function load( ttype, match_map, hs_sys_dir )
 				obj2.height   = obj2.texture_height;
 				obj2.rotation = obj.rotation;
 
-				if ( vid_below )
-					obj2.zorder = obj.zorder-1;
+				if ( overlay_below )
+					obj2.zorder = ::hs_ent["video"].zorder-1;
 			}
 
 			if ( r != 0 )
@@ -776,15 +787,8 @@ function load( ttype, match_map, hs_sys_dir )
 
 	//below seems to swap zorder of video + overlay with artwork 1
 	//
-	if ( below )
-	{
-		if ( found_tags["artwork1"] )
-			//  we only need to update artwork1 zorder to "3" zorder of 
-			//  the artworks with lower zorder seem to change
-			//  automatically, verified with print statements
-			//
-			::hs_ent["artwork1"].obj.zorder = 3;
-	}
+	if ( below && found_tags["artwork1"] )
+		::hs_ent["artwork1"].obj.zorder = ::hs_ent["video_overlay"].zorder + 1;
 
 	return call_into_transition;
 }

--- a/src/fe_presentable.cpp
+++ b/src/fe_presentable.cpp
@@ -26,7 +26,8 @@
 FeBasePresentable::FeBasePresentable( FePresentableParent &p )
 	: m_parent( p ),
 	m_shader( NULL ),
-	m_visible( true )
+	m_visible( true ),
+	m_zorder( 0 )
 {
 }
 
@@ -189,33 +190,26 @@ void FeBasePresentable::script_set_shader( FeShader *sh )
 
 int FeBasePresentable::get_zorder()
 {
-	for ( size_t i=0; i< m_parent.elements.size(); i++ )
-	{
-		if ( this == m_parent.elements[i] )
-			return i;
-	}
-
-	return -1;
+	return m_zorder;
 }
+
+namespace
+{
+	bool zcompare( FeBasePresentable *one, FeBasePresentable *two )
+	{
+		return ( one->get_zorder() < two->get_zorder() );
+	}
+};
 
 void FeBasePresentable::set_zorder( int pos )
 {
-	if ( pos >= (int)m_parent.elements.size() )
-		pos = m_parent.elements.size()-1;
-	if ( pos < 0 )
-		pos = 0;
+	if ( pos == m_zorder )
+		return;
 
-	int old = get_zorder();
-	if (( old >= 0 ) && ( old != pos ))
-	{
-		FeBasePresentable *temp = m_parent.elements[old];
-		m_parent.elements.erase( m_parent.elements.begin() + old );
+	m_zorder = pos;
 
-		m_parent.elements.insert( m_parent.elements.begin() + pos,
-			temp );
-
-		FePresent::script_flag_redraw();
-	}
+	std::stable_sort( m_parent.elements.begin(), m_parent.elements.end(), zcompare );
+	FePresent::script_flag_redraw();
 }
 
 FeImage *FePresentableParent::add_image(const char *n, int x, int y, int w, int h)

--- a/src/fe_presentable.hpp
+++ b/src/fe_presentable.hpp
@@ -42,6 +42,7 @@ private:
 	FePresentableParent &m_parent;
 	FeShader *m_shader;
 	bool m_visible;
+	int m_zorder;
 
 public:
 	FeBasePresentable( FePresentableParent &p );


### PR DESCRIPTION
- This changes the behaviour of the zorder attribute of image, text,
  and listbox objects.  *** Layouts that use the zorder attribute
  may have to be updated as a result ***

- zorder attribute can be set to any integer value.  The value stays
  at whatever it is set to (previous behaviour was that all objects
  had a unique zorder value, forced in to the range of 0 to number
  of objects-1)

- objects with a lower zorder are drawn first.  Order remains stable
  when objects are assigned the same zorder.

- Default zorder value is 0, with objects drawn in their order of
  creation

- updates to loader/hyperspin.nut to address zorder changes