### PR TITLE
Added manifest to Windows build

### DIFF
--- a/src/attract.exe.manifest
+++ b/src/attract.exe.manifest
@@ -1,0 +1,7 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" >
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <dpiAware>true</dpiAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>

--- a/src/attract.rc
+++ b/src/attract.rc
@@ -1,3 +1,7 @@
+#define RT_MANIFEST 24  
+#define APP_MANIFEST 1 
+APP_MANIFEST RT_MANIFEST attract.exe.manifest 
+
 #define STRINGIZE_HELPER(...) #__VA_ARGS__
 #define STRINGIZE(x) STRINGIZE_HELPER(x)
 


### PR DESCRIPTION
Even though Windows' DPI scaling other than 100% does not affect the scaling of drawables it has an impact on the vsync. I've set dpiAware to true, so the system does not interfere and there is no stuttering in fullscreen.