### PR TITLE
True borderless window mode added

### DIFF
--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -201,6 +201,7 @@ const char *FeSettings::windowModeTokens[] =
 	"fullscreen",
 	"window",
 	"window_no_border",
+	"borderless_fullscreen",
 	NULL
 };
 
@@ -210,6 +211,7 @@ const char *FeSettings::windowModeDispTokens[] =
 	"Fullscreen Mode",
 	"Window",
 	"Window (No Border)",
+	"Borderless Fullscreen",
 	NULL
 };
 

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -88,7 +88,7 @@ public:
 		ScreenSaver_Showing
 	};
 
-	enum WindowType { Default=0, Fullscreen, Window, WindowNoBorder };
+	enum WindowType { Default=0, Fullscreen, Window, WindowNoBorder, BorderlessFullscreen };
 	static const char *windowModeTokens[];
 	static const char *windowModeDispTokens[];
 

--- a/src/fe_window.cpp
+++ b/src/fe_window.cpp
@@ -177,12 +177,13 @@ void FeWindow::onCreate()
 
 void FeWindow::initial_create()
 {
-	int style_map[4] =
+	int style_map[5] =
 	{
 		sf::Style::None,			// FeSettings::Default
 		sf::Style::Fullscreen,	// FeSettings::Fullscreen
 		sf::Style::Default,		// FeSettings::Window
-		sf::Style::None			// FeSettings::WindowNoBorder
+		sf::Style::None,			// FeSettings::WindowNoBorder
+		sf::Style::None				// FeSettings::BorderlessFullscreen
 	};
 
 	int win_mode = m_fes.get_window_mode();


### PR DESCRIPTION
Borderless Fullscreen mode works in the same way as Window ( no border ) mode, but it sets the window size to the desktop resolution rather than previously set window size stored in window.am file. This way you get full optimization given by the system and no stuttering.
note: Needs to be checked on Linux and OSX, just to be sure it works as intended.