### PR TITLE
Texture double-buffering implementation

### DIFF
--- a/src/fe_image.cpp
+++ b/src/fe_image.cpp
@@ -259,6 +259,11 @@ FeTextureContainer::FeTextureContainer(
 
 FeTextureContainer::~FeTextureContainer()
 {
+	delete m_texture[0];
+	delete m_texture[1];
+	m_texture[0] = NULL;
+	m_texture[1] = NULL;
+
 #ifndef NO_MOVIE
 	if ( m_movie )
 	{

--- a/src/fe_image.hpp
+++ b/src/fe_image.hpp
@@ -159,6 +159,7 @@ public:
 
 	void set_mipmap( bool );
 	bool get_mipmap() const;
+	void swap_texture_buffers();
 
 protected:
 	FeTextureContainer *get_derived_texture_container();
@@ -182,7 +183,8 @@ private:
 	void internal_update_selection( FeSettings *feSettings );
 	void clear();
 
-	sf::Texture m_texture;
+	sf::Texture *m_texture[2];
+	int m_active_texture;
 
 	std::string m_art_name; // artwork label/template name (dynamic images)
 	std::string m_file_name; // the name of the loaded file


### PR DESCRIPTION
Images now have 2 buffers. While one is being drawn the other is filled with new data. This speeds up the loading of textures by up to 16ms as the driver does not have to wait until the old texture has finished drawing. This commit gives grounds for my upcoming commit that implements reuse of previously loaded textures.