### PR TITLE
Added new fe.Text property msg_wrapped

### DIFF
--- a/Layouts.md
+++ b/Layouts.md
@@ -1618,6 +1618,7 @@ otherwise instantiated in a script.
 Properties:
    * `msg` - Get/set the text label's message.  Magic tokens can be used here,
      see [Magic Tokens](#magic) for more information.
+   * `msg_wrapped` - Get the text label's message after word wrapping.
    * `x` - Get/set x position of top left corner (in layout coordinates).
    * `y` - Get/set y position of top left corner (in layout coordinates).
    * `width` - Get/set width of text (in layout coordinates).

--- a/src/fe_text.cpp
+++ b/src/fe_text.cpp
@@ -227,6 +227,11 @@ const char *FeText::get_string()
 	return m_string.c_str();
 }
 
+const char *FeText::get_string_wrapped()
+{
+	return m_draw_text.getStringWrapped();
+}
+
 void FeText::set_string(const char *s)
 {
 	m_string=s;

--- a/src/fe_text.hpp
+++ b/src/fe_text.hpp
@@ -76,6 +76,7 @@ public:
 
 	const char *get_string();
 	void set_string(const char *s);
+	const char *get_string_wrapped();
 
 	int get_actual_width() { return m_draw_text.getActualWidth(); };
 

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -700,6 +700,7 @@ bool FeVM::on_new_layout()
 	fe.Bind( _SC("Text"),
 		DerivedClass<FeText, FeBasePresentable, NoConstructor>()
 		.Prop(_SC("msg"), &FeText::get_string, &FeText::set_string )
+		.Prop(_SC("msg_wrapped"), &FeText::get_string_wrapped )
 		.Prop(_SC("bg_red"), &FeText::get_bgr, &FeText::set_bgr )
 		.Prop(_SC("bg_green"), &FeText::get_bgg, &FeText::set_bgg )
 		.Prop(_SC("bg_blue"), &FeText::get_bgb, &FeText::set_bgb )

--- a/src/tp.cpp
+++ b/src/tp.cpp
@@ -587,6 +587,17 @@ int FeTextPrimative::getFirstLineHint() const
 	return m_first_line;
 }
 
+const char *FeTextPrimative::getStringWrapped()
+{
+	std::string str;
+	for ( unsigned int i=0; i < m_texts.size(); i++ )
+	{
+		str += m_texts[i].getString();
+		str += "\n";
+	}
+	return str.c_str();
+}
+
 void FeTextPrimative::draw( sf::RenderTarget &target, sf::RenderStates states ) const
 {
 	if ( m_needs_pos_set )

--- a/src/tp.hpp
+++ b/src/tp.hpp
@@ -99,6 +99,7 @@ public:
 	int getStyle() const;
 	int getFirstLineHint() const;
 	const sf::Vector2f &getTextScale() const;
+	const char *getStringWrapped();
 
 	int getActualWidth(); // return the width of the actual text
 


### PR DESCRIPTION
Allows to retrieve text of the object after word wrapping.

Example nut file:
```
local t1 = fe.add_text ( "Lorem ipsum dolor sit amet consectetur adipiscing elit", 0, 0, 400, 400 )
t1.set_bg_rgb( 200, 100, 100 )
t1.char_size = 40
t1.word_wrap = true
t1.align = Align.TopLeft

local t2 = fe.add_text ( "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua", 400, 0, 400, 400 )
t2.set_bg_rgb( 100, 200, 100 )
t2.char_size = 40
t2.word_wrap = true
t2.align = Align.TopLeft

local t3 = fe.add_text ( t1.msg + " " +  t2.msg, 0, 400, 800, 800 )
t3.set_bg_rgb( 100, 100, 100 )
t3.char_size = 40
t3.word_wrap = true
t3.align = Align.TopLeft

local t4 = fe.add_text ( t1.msg_wrapped + t2.msg_wrapped, 800, 400, 800, 800 )
t4.set_bg_rgb( 100, 100, 200 )
t4.char_size = 40
t4.word_wrap = true
t4.align = Align.TopLeft

function tick( ttime )
{
	t3.char_size = 40 + cos( ttime * 0.005 ) * 10.0
	t4.char_size = 40 + cos( ttime * 0.005 ) * 10.0
}
fe.add_ticks_callback( "tick" )
```
