### PR TITLE
Updated nowide to fix crashing on Windows

### DIFF
--- a/extlibs/nowide/iostream.cpp
+++ b/extlibs/nowide/iostream.cpp
@@ -77,12 +77,12 @@ namespace details {
             wchar_t *out = wbuffer_;
             uf::code_point c;
             size_t decoded = 0;
-            while(p < e && (c = uf::utf_traits<char>::decode(p,e))!=uf::illegal && c!=uf::incomplete) {
+            while(p < e && (c = uf::utf_traits<char>::decode(p,e))!=uf::incomplete) {
+                if(c == uf::illegal)
+                    c = NOWIDE_REPLACEMENT_CHARACTER;
                 out = uf::utf_traits<wchar_t>::encode(c,out);
                 decoded = p-b;
             }
-            if(c==uf::illegal)
-                return -1;
             if(!WriteConsoleW(handle_,wbuffer_,out - wbuffer_,&size,0))
                 return -1;
             return decoded;

--- a/extlibs/nowide/nowide/args.hpp
+++ b/extlibs/nowide/nowide/args.hpp
@@ -95,13 +95,8 @@ namespace nowide {
             try{ 
                 args_.resize(wargc+1,0);
                 arg_values_.resize(wargc);
-                for(int i=0;i<wargc;i++) {
-                    if(!arg_values_[i].convert(wargv[i])) {
-                        wargc = i;
-                        break;
-                    }
-                    args_[i] = arg_values_[i].c_str();
-                }
+                for(int i=0;i<wargc;i++) 
+                    args_[i] = arg_values_[i].convert(wargv[i]);
                 argc = wargc;
                 argv = &args_[0];
             }
@@ -123,17 +118,16 @@ namespace nowide {
                 int count = 0;
                 for(wstrings_end = wstrings;*wstrings_end;wstrings_end+=wcslen(wstrings_end)+1)
                         count++;
-                if(env_.convert(wstrings,wstrings_end)) {
-                    envp_.resize(count+1,0);
-                    char *p=env_.c_str();
-                    int pos = 0;
-                    for(int i=0;i<count;i++) {
-                        if(*p!='=')
-                            envp_[pos++] = p;
-                        p+=strlen(p)+1;
-                    }
-                    en = &envp_[0];
+                env_.convert(wstrings,wstrings_end);
+                envp_.resize(count+1,0);
+                char *p=env_.c_str();
+                int pos = 0;
+                for(int i=0;i<count;i++) {
+                    if(*p!='=')
+                        envp_[pos++] = p;
+                    p+=strlen(p)+1;
                 }
+                en = &envp_[0];
             }
             catch(...) {
                 FreeEnvironmentStringsW(wstrings);

--- a/extlibs/nowide/nowide/cenv.hpp
+++ b/extlibs/nowide/nowide/cenv.hpp
@@ -36,9 +36,7 @@ namespace nowide {
     {
         static stackstring value;
         
-        wshort_stackstring name;
-        if(!name.convert(key))
-            return 0;
+        wshort_stackstring name(key);
 
         static const size_t buf_size = 64;
         wchar_t buf[buf_size];
@@ -55,8 +53,7 @@ namespace nowide {
                 return 0;
             ptr = &tmp[0];
         }
-        if(!value.convert(ptr))
-            return 0;
+        value.convert(ptr);
         return value.c_str();
     }
     ///
@@ -67,17 +64,13 @@ namespace nowide {
     ///
     inline int setenv(char const *key,char const *value,int override)
     {
-        wshort_stackstring name;
-        if(!name.convert(key))
-            return -1;
+        wshort_stackstring name(key);
         if(!override) {
             wchar_t unused[2];
             if(!(GetEnvironmentVariableW(name.c_str(),unused,2)==0 && GetLastError() == 203)) // ERROR_ENVVAR_NOT_FOUND
                 return 0;
         }
-        wstackstring wval;
-        if(!wval.convert(value))
-            return -1;
+        wstackstring wval(value);
         if(SetEnvironmentVariableW(name.c_str(),wval.c_str()))
             return 0;
         return -1;
@@ -87,9 +80,7 @@ namespace nowide {
     ///
     inline int unsetenv(char const *key)
     {
-        wshort_stackstring name;
-        if(!name.convert(key))
-            return -1;
+        wshort_stackstring name(key);
         if(SetEnvironmentVariableW(name.c_str(),0))
             return 0;
         return -1;
@@ -106,12 +97,10 @@ namespace nowide {
         if(*key_end == '\0')
             return -1;
         wshort_stackstring wkey;
-        if(!wkey.convert(key,key_end))
-            return -1;
-        
         wstackstring wvalue;
-        if(!wvalue.convert(key_end+1))
-            return -1;
+
+        wkey.convert(key,key_end);
+        wvalue.convert(key_end+1);
 
         if(SetEnvironmentVariableW(wkey.c_str(),wvalue.c_str()))
             return 0;

--- a/extlibs/nowide/nowide/config.hpp
+++ b/extlibs/nowide/nowide/config.hpp
@@ -17,16 +17,6 @@
 #define NOWIDE_MSVC
 #endif
 
-#ifdef NOWIDE_WINDOWS
-#   if defined(DLL_EXPORT) || defined(NOWIDE_EXPORT)
-#       ifdef NOWIDE_SOURCE
-#           define NOWIDE_DECL __declspec(dllexport)
-#       else
-#           define NOWIDE_DECL __declspec(dllimport)
-#       endif  //NOWIDE_SOURCE
-#   endif  // DYN_LINK
-#endif  
-
 #ifndef NOWIDE_DECL
 #   define NOWIDE_DECL
 #endif

--- a/extlibs/nowide/nowide/cstdio.hpp
+++ b/extlibs/nowide/nowide/cstdio.hpp
@@ -33,59 +33,35 @@ namespace nowide {
 ///
 /// \brief Same as freopen but file_name and mode are UTF-8 strings
 ///
-/// If invalid UTF-8 given, NULL is returned and errno is set to EINVAL
-///
 inline FILE *freopen(char const *file_name,char const *mode,FILE *stream)
 {
-    wstackstring wname;
-    wshort_stackstring wmode;
-    if(!wname.convert(file_name) || !wmode.convert(mode)) {
-        errno = EINVAL;
-        return 0;
-    }
+    wstackstring wname(file_name);
+    wshort_stackstring wmode(mode);
     return _wfreopen(wname.c_str(),wmode.c_str(),stream);
 }
 ///
 /// \brief Same as fopen but file_name and mode are UTF-8 strings
 ///
-/// If invalid UTF-8 given, NULL is returned and errno is set to EINVAL
-///
 inline FILE *fopen(char const *file_name,char const *mode)
 {
-    wstackstring wname;
-    wshort_stackstring wmode;
-    if(!wname.convert(file_name) || !wmode.convert(mode)) {
-        errno = EINVAL;
-        return 0;
-    }
+    wstackstring wname(file_name);
+    wshort_stackstring wmode(mode);
     return _wfopen(wname.c_str(),wmode.c_str());
 }
 ///
 /// \brief Same as rename but old_name and new_name are UTF-8 strings
 ///
-/// If invalid UTF-8 given, -1 is returned and errno is set to EINVAL
-///
 inline int rename(char const *old_name,char const *new_name)
 {
-    wstackstring wold,wnew;
-    if(!wold.convert(old_name) || !wnew.convert(new_name)) {
-        errno = EINVAL;
-        return -1;
-    }
+    wstackstring wold(old_name),wnew(new_name);
     return _wrename(wold.c_str(),wnew.c_str());
 }
 ///
 /// \brief Same as rename but name is UTF-8 string
 ///
-/// If invalid UTF-8 given, -1 is returned and errno is set to EINVAL
-///
 inline int remove(char const *name)
 {
-    wstackstring wname;
-    if(!wname.convert(name)) {
-        errno = EINVAL;
-        return -1;
-    }
+    wstackstring wname(name);
     return _wremove(wname.c_str());
 }
 #endif

--- a/extlibs/nowide/nowide/filebuf.hpp
+++ b/extlibs/nowide/nowide/filebuf.hpp
@@ -50,7 +50,7 @@ namespace nowide {
         /// Creates new filebuf
         ///
         basic_filebuf() : 
-            buffer_size_(4),
+            buffer_size_(BUFSIZ),
             buffer_(0),
             file_(0),
             own_(true),
@@ -93,11 +93,9 @@ namespace nowide {
             wchar_t const *smode = get_mode(mode);
             if(!smode)
                 return 0;
-            wstackstring name;
-            if(!name.convert(s)) 
-                return 0;
+            wstackstring name(s);
             #ifdef NOWIDE_FSTREAM_TESTS
-            FILE *f = ::fopen(s,nowide::convert(smode).c_str());
+            FILE *f = ::fopen(s,nowide::narrow(smode).c_str());
             #else
             FILE *f = ::_wfopen(name.c_str(),smode);
             #endif
@@ -260,13 +258,14 @@ namespace nowide {
                 }
                 last_char_ = c;
                 setg(&last_char_,&last_char_,&last_char_ + 1);
-                return c;
             }
-            make_buffer();
-            size_t n = ::fread(buffer_,1,buffer_size_,file_);
-            setg(buffer_,buffer_,buffer_+n);
-            if(n == 0)
-                return EOF;
+            else {
+                make_buffer();
+                size_t n = ::fread(buffer_,1,buffer_size_,file_);
+                setg(buffer_,buffer_,buffer_+n);
+                if(n == 0)
+                    return EOF;
+            }
             return std::char_traits<char>::to_int_type(*gptr());
         }
 

--- a/extlibs/nowide/nowide/replacement.hpp
+++ b/extlibs/nowide/nowide/replacement.hpp
@@ -1,0 +1,16 @@
+//
+//  Copyright (c) 2018 Artyom Beilis (Tonkikh)
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+#ifndef NOWIDE_REPLACEMENT_HPP_INCLUDED
+#define NOWIDE_REPLACEMENT_HPP_INCLUDED
+
+#ifndef NOWIDE_REPLACEMENT_CHARACTER
+#define NOWIDE_REPLACEMENT_CHARACTER 0xFFFD
+#endif
+
+#endif // boost/nowide/replacement.hpp
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/extlibs/nowide/nowide/system.hpp
+++ b/extlibs/nowide/nowide/system.hpp
@@ -23,17 +23,11 @@ using ::system;
 ///
 /// Same as std::system but cmd is UTF-8.
 ///
-/// If the input is not valid UTF-8, -1 returned and errno set to EINVAL
-///
 inline int system(char const *cmd)
 {
     if(!cmd)
         return _wsystem(0);
-    wstackstring wcmd;
-    if(!wcmd.convert(cmd)) {
-        errno = EINVAL;
-        return -1;
-    }
+    wstackstring wcmd(cmd);
     return _wsystem(wcmd.c_str());
 }
 

--- a/extlibs/nowide/nowide/windows.hpp
+++ b/extlibs/nowide/nowide/windows.hpp
@@ -10,10 +10,6 @@
 
 #include <stddef.h>
 
-#ifdef NOWIDE_USE_WINDOWS_H
-#include <windows.h>
-#else
-
 //
 // These are function prototypes... Allow to to include windows.h
 //
@@ -29,9 +25,6 @@ __declspec(dllimport) int             __stdcall SetEnvironmentVariableW(wchar_t 
 __declspec(dllimport) unsigned long   __stdcall GetEnvironmentVariableW(wchar_t const *,wchar_t *,unsigned long);
 
 }
-
-#endif 
-
 
 
 #endif


### PR DESCRIPTION
This was apparent on calling nowide:cout to null device by the video threads. Most apparent in Filter Grid layout ( with transition time set to 0 and holding left or right )