### PR TITLE
Increased video timeout to 5 seconds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
   - os: osx
     compiler: gcc
 before_install:
-- if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update --all; fi
+- if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
 install:
 - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install ffmpeg sfml libarchive curl; fi
 script:

--- a/src/media.cpp
+++ b/src/media.cpp
@@ -622,7 +622,7 @@ void FeVideoImp::video_thread()
 		// so we flag the video to be restarted on the next tick.
 		// This prevents displaying only keyframes for several seconds on wake.
 		//
-		if ( wait_time < sf::seconds( -2.0f ) )
+		if ( wait_time < sf::seconds( -5.0f ) )
 		{
 			wait_time = sf::seconds( 0 );
 			far_behind = true;


### PR DESCRIPTION
2 seconds timeout was causing unintentional restarts of videos on the Raspberry PI.