### PR TITLE
Improved decoding quality of videos with non 1:1 pixel aspect ratio

### DIFF
--- a/src/fe_image.cpp
+++ b/src/fe_image.cpp
@@ -127,6 +127,11 @@ bool FeBaseTextureContainer::is_swf() const
 	return false;
 }
 
+float FeBaseTextureContainer::get_movie_aspect_ratio() const
+{
+	return 1.0;
+}
+
 void FeBaseTextureContainer::transition_swap( FeBaseTextureContainer *o )
 {
 	//
@@ -1000,6 +1005,14 @@ bool FeTextureContainer::is_swf() const
 	return m_swf;
 }
 
+float FeTextureContainer::get_movie_aspect_ratio() const
+{
+	if ( m_movie )
+		m_movie->get_aspect_ratio();
+	else
+		return 1.0;
+}
+
 void FeTextureContainer::release_audio( bool state )
 {
 #ifndef NO_MOVIE
@@ -1204,6 +1217,7 @@ void FeImage::draw(sf::RenderTarget& target, sf::RenderStates states) const
 void FeImage::scale()
 {
 	sf::IntRect texture_rect = m_sprite.getTextureRect();
+	float ratio = m_tex->get_movie_aspect_ratio();
 
 	if (( texture_rect.width == 0 ) || ( texture_rect.height == 0 ))
 		return;
@@ -1240,25 +1254,25 @@ void FeImage::scale()
 				sf::Transform t;
 				t.rotate( m_sprite.getRotation() );
 
-				if ( scale_x > scale_y ) // centre in x direction
+				if ( scale_x > scale_y * ratio ) // centre in x direction
 					final_pos += t.transformPoint(
-						( m_size.x - ( abs( texture_rect.width ) * scale_y )) / 2.0,
+						( m_size.x - abs( texture_rect.width ) * scale_y * ratio ) / 2.0,
 						0 );
 				else // centre in y direction
 					final_pos += t.transformPoint( 0,
-						( m_size.y - ( abs( texture_rect.height ) * scale_x )) / 2.0);
+						( m_size.y - abs( texture_rect.height ) * scale_x / ratio ) / 2.0 );
 			}
 		}
 
 		scale = true;
 	}
 
-	if ( m_preserve_aspect_ratio && ( scale_y != scale_x ))
+	if ( m_preserve_aspect_ratio )
 	{
-		if ( scale_y > scale_x )
-			scale_y = scale_x;
+		if ( scale_y * ratio > scale_x )
+			scale_y = scale_x / ratio;
 		else
-			scale_x = scale_y;
+			scale_x = scale_y * ratio;
 	}
 
 	if ( scale )

--- a/src/fe_image.cpp
+++ b/src/fe_image.cpp
@@ -1007,9 +1007,10 @@ bool FeTextureContainer::is_swf() const
 
 float FeTextureContainer::get_movie_aspect_ratio() const
 {
+#ifndef NO_MOVIE
 	if ( m_movie )
-		m_movie->get_aspect_ratio();
-	else
+		return m_movie->get_aspect_ratio();
+#endif
 		return 1.0;
 }
 

--- a/src/fe_image.hpp
+++ b/src/fe_image.hpp
@@ -87,6 +87,7 @@ public:
 	virtual void set_mipmap( bool )=0;
 	virtual bool get_mipmap() const=0;
 	virtual bool is_swf() const;
+	virtual float get_movie_aspect_ratio() const;
 
 	// function for use with surface objects
 	//
@@ -161,6 +162,7 @@ public:
 	void set_mipmap( bool );
 	bool get_mipmap() const;
 	bool is_swf() const;
+	float get_movie_aspect_ratio() const;
 
 protected:
 	FeTextureContainer *get_derived_texture_container();

--- a/src/media.cpp
+++ b/src/media.cpp
@@ -790,7 +790,8 @@ the_end:
 FeMedia::FeMedia( Type t )
 	: sf::SoundStream(),
 	m_audio( NULL ),
-	m_video( NULL )
+	m_video( NULL ),
+	m_aspect_ratio( 1.0 )
 {
 	m_imp = new FeMediaImp( t );
 }
@@ -1090,11 +1091,12 @@ bool FeMedia::open( const std::string &archive,
 
 				m_video->max_sleep = sf::seconds( 0.5 / av_q2d(m_imp->m_format_ctx->streams[stream_id]->r_frame_rate));
 
-				float aspect_ratio = 1.0;
 				if ( codec_ctx->sample_aspect_ratio.num != 0 )
-					aspect_ratio = av_q2d( codec_ctx->sample_aspect_ratio );
+					m_aspect_ratio = av_q2d( codec_ctx->sample_aspect_ratio );
+				if ( m_imp->m_format_ctx->streams[stream_id]->sample_aspect_ratio.num != 0 )
+					m_aspect_ratio = av_q2d( m_imp->m_format_ctx->streams[stream_id]->sample_aspect_ratio );
 
-				m_video->disptex_width = codec_ctx->width * aspect_ratio;
+				m_video->disptex_width = codec_ctx->width;
 				m_video->disptex_height = codec_ctx->height;
 
 				m_video->display_texture = outt;
@@ -1397,6 +1399,11 @@ bool FeMedia::is_multiframe() const
 	}
 
 	return false;
+}
+
+float FeMedia::get_aspect_ratio() const
+{
+	return m_aspect_ratio;
 }
 
 sf::Time FeMedia::get_duration() const

--- a/src/media.hpp
+++ b/src/media.hpp
@@ -79,6 +79,7 @@ public:
 
 	bool is_playing();
 	bool is_multiframe() const;
+	float get_aspect_ratio() const;
 
 	sf::Time get_video_time();
 	sf::Time get_duration() const;
@@ -119,6 +120,7 @@ private:
 	FeMedia( const FeMedia & );
 	FeMedia &operator=( const FeMedia & );
 	static void init_av();
+	float m_aspect_ratio;
 };
 
 #endif


### PR DESCRIPTION
Many video snaps have non square pixel aspect ratio ( mostly MAME snaps ). This commit moves applying pixel aspect ratio from FeMedia ( on texture creation ) to FeImage ( sprite transform ).