### PR TITLE
Fixed low framerate on AMD cards

### DIFF
--- a/src/fe_overlay.cpp
+++ b/src/fe_overlay.cpp
@@ -194,7 +194,7 @@ private:
 	bool m_flag_set;
 };
 
-FeOverlay::FeOverlay( sf::RenderWindow &wnd,
+FeOverlay::FeOverlay( FeWindow &wnd,
 		FeSettings &fes,
 		FePresent &fep )
 	: m_wnd( wnd ),
@@ -1511,9 +1511,9 @@ bool FeOverlay::event_loop( FeEventLoopCtx &ctx )
 class FeKeyRepeat
 {
 private:
-	sf::RenderWindow &m_wnd;
+	FeWindow &m_wnd;
 public:
-	FeKeyRepeat( sf::RenderWindow &wnd )
+	FeKeyRepeat( FeWindow &wnd )
 	: m_wnd( wnd )
 	{
 		m_wnd.setKeyRepeatEnabled( true );

--- a/src/fe_overlay.hpp
+++ b/src/fe_overlay.hpp
@@ -25,6 +25,7 @@
 
 #include <SFML/Graphics.hpp>
 #include "fe_present.hpp"
+#include "fe_window.hpp"
 
 class FeSettings;
 class FeInputMapEntry;
@@ -38,7 +39,7 @@ class FeOverlay
 friend class FeConfigContextImp;
 
 private:
-	sf::RenderWindow &m_wnd;
+	FeWindow &m_wnd;
 	FeSettings &m_feSettings;
 	FePresent &m_fePresent;
 	const sf::Color m_textColour;
@@ -66,7 +67,7 @@ private:
 			std::basic_string<sf::Uint32> &str, FeTextPrimative *lb );
 
 public:
-	FeOverlay( sf::RenderWindow &wnd,
+	FeOverlay( FeWindow &wnd,
 		FeSettings &fes,
 		FePresent &fep );
 

--- a/src/fe_window.cpp
+++ b/src/fe_window.cpp
@@ -133,7 +133,17 @@ FeWindow::~FeWindow()
 
 void FeWindow::onCreate()
 {
+	// On Windows Vista and above all non fullscreen window modes
+	// go through DWM. We have to disable vsync
+	// when we rely solely on DwmFlush()
+#if defined(SFML_SYSTEM_WINDOWS) && !defined(WINDOWS_XP)
+	if ( m_win_mode != FeSettings::Fullscreen )
+		setVerticalSyncEnabled(false);
+	else
+		setVerticalSyncEnabled(true);
+#else
 	setVerticalSyncEnabled(true);
+#endif
 	setKeyRepeatEnabled(false);
 	setMouseCursorVisible(false);
 	setJoystickThreshold( 1.0 );


### PR DESCRIPTION
On AMD cards windowed modes have decreased framerate by half caused by DwmFlush and OGL Vsync doing double wait.
As a fix in window modes other than fullscreen we disable vsync and let dwmapi to handle waiting. 