### PR TITLE
Additional window modes fixes

### DIFF
--- a/src/fe_window.cpp
+++ b/src/fe_window.cpp
@@ -143,6 +143,8 @@ void FeWindow::onCreate()
 
 void FeWindow::display()
 {
+	sf::RenderWindow::display();
+
 	// Starting from Windows Vista all non fullscreen window modes
 	// go through DWM, so we have to flush here to sync to the DMW's v-sync
 	// to avoid stuttering.
@@ -150,17 +152,25 @@ void FeWindow::display()
 	if ( m_win_mode != FeSettings::Fullscreen )
 		DwmFlush();
 #endif
-	sf::RenderWindow::display();
 }
 
 void FeWindow::initial_create()
 {
 	int style_map[4] =
 	{
-		sf::Style::None,			// FeSettings::Default
-		sf::Style::Fullscreen,	// FeSettings::Fullscreen
-		sf::Style::Default,		// FeSettings::Window
-		sf::Style::None			// FeSettings::WindowNoBorder
+		sf::Style::None,       // FeSettings::Default
+		// On Windows Vista and above we do not set fullscreen flag explicitly.
+		// Instead we create a fullscreen borderless window, and let the system handle it.
+		// When the window resolution matches the display resolution
+		// we have all the advantages of native fullscreen
+		// double/triple buffering, fullscreen optimizations and faster window creation/switching
+#if defined(SFML_SYSTEM_WINDOWS) && !defined(WINDOWS_XP)
+		sf::Style::None,       // FeSettings::Fullscreen
+#else
+		sf::Style::Fullscreen, // FeSettings::Fullscreen
+#endif
+		sf::Style::Default,    // FeSettings::Window
+		sf::Style::None        // FeSettings::WindowNoBorder
 	};
 
 	sf::VideoMode vm = sf::VideoMode::getDesktopMode(); // width/height/bpp of OpenGL surface to create
@@ -288,6 +298,30 @@ void FeWindow::initial_create()
 
 	sf::Vector2u wsize( vm.width, vm.height );
 
+#if defined(SFML_SYSTEM_WINDOWS)
+	// To avoid problems with black screen on launching games when window mode is set to Fullscreen
+	// we hide the main renderwindow and show this m_blackout window instead
+	// which has the extended size by 1 pixel in each direction to stop Windows
+	// from treating it as exclusive borderless.
+	//
+	if ( m_win_mode == FeSettings::Fullscreen )
+	{
+		m_blackout.create(sf::VideoMode(16, 16, 24), "", sf::Style::None);
+		m_blackout.setSize( sf::Vector2u( vm.width + 2, vm.height + 2 ));
+		m_blackout.setPosition( sf::Vector2i( -1, -1 ));
+		m_blackout.setVerticalSyncEnabled(true);
+		m_blackout.setKeyRepeatEnabled(false);
+		m_blackout.setMouseCursorVisible(false);
+
+
+		// We hide the black window from the task bar and the alt+tab switcher
+		int style = GetWindowLongPtr(m_blackout.getSystemHandle(), GWL_EXSTYLE );
+		SetWindowLongPtr( m_blackout.getSystemHandle(), GWL_EXSTYLE, style | WS_EX_TOOLWINDOW );
+		m_blackout.clear();
+		m_blackout.display();
+	}
+#endif
+
 	//
 	// Create window
 	//
@@ -309,7 +343,6 @@ void FeWindow::initial_create()
 	// Known issue: Linux Mint 18.3 Cinnamon w/ SFML 2.5.1, position isn't being set
 	// (Window always winds up at 0,0)
 	setPosition( wpos );
-	setSize( wsize );
 
 	FeDebug() << "Created Attract-Mode Window: " << wsize.x << "x" << wsize.y << " @ "
 		<< wpos.x << "," << wpos.y << " [OpenGL surface: "
@@ -330,31 +363,7 @@ void FeWindow::initial_create()
 		&& ( vm.height == wsize.y ))
 		m_win_mode = FeSettings::Fullscreen;
 #endif
-
-	// To avoid problems with black screen on launching games when window mode is set to Fullscreen
-	// we hide the main renderwindow and show this m_blackout window instead
-	// which has the extended size by 1 pixel in each direction to stop Windows
-	// from treating it as exclusive borderless.
-	//
-	if ( m_win_mode == FeSettings::Fullscreen )
-	{
-		m_blackout.create(sf::VideoMode(16, 16, 32), "", sf::Style::None);
-		m_blackout.setVerticalSyncEnabled(true);
-		m_blackout.setKeyRepeatEnabled(false);
-		m_blackout.setMouseCursorVisible(false);
-		m_blackout.setSize( sf::Vector2u( vm.width + 2, vm.height + 2 ));
-		m_blackout.setPosition( sf::Vector2i( -1, -1 ));
-		m_blackout.display();
-
-		// We hide the black window from the task bar and the alt+tab switcher
-		int style = GetWindowLongPtr(m_blackout.getSystemHandle(), GWL_EXSTYLE );
-		SetWindowLongPtr( m_blackout.getSystemHandle(), GWL_EXSTYLE, style | WS_EX_TOOLWINDOW );
-	}
-
-	if (( m_win_mode == FeSettings::Fullscreen ) || ( m_win_mode == FeSettings::Window ))
-		set_win32_foreground_window( getSystemHandle(), HWND_TOP );
-	else
-		set_win32_foreground_window( getSystemHandle(), HWND_TOPMOST );
+	set_win32_foreground_window( getSystemHandle(), HWND_TOP );
 #endif
 
 	m_fes.init_mouse_capture( wsize.x, wsize.y );
@@ -447,7 +456,7 @@ bool FeWindow::run()
 	bool have_paused_prog = m_running_pid && process_exists( m_running_pid );
 
 #if defined(SFML_SYSTEM_WINDOWS)
-	if (( m_win_mode == FeSettings::Fullscreen ) || ( m_win_mode == FeSettings::Window ))
+	if ( m_win_mode == FeSettings::Fullscreen )
 	{
 		set_win32_foreground_window( getSystemHandle(), HWND_BOTTOM );
 		m_blackout.display();
@@ -604,7 +613,7 @@ bool FeWindow::run()
 #elif defined(SFML_SYSTEM_MACOS)
 	osx_take_focus();
 #elif defined(SFML_SYSTEM_WINDOWS)
-	if (( m_win_mode == FeSettings::Fullscreen ) || ( m_win_mode == FeSettings::Window ))
+	if ( m_win_mode == FeSettings::Fullscreen )
 	{
 		m_blackout.display();
 		setVisible( true );
@@ -620,7 +629,7 @@ bool FeWindow::run()
 		set_win32_foreground_window( getSystemHandle(), HWND_TOP );
 	}
 	else
-		set_win32_foreground_window( getSystemHandle(), HWND_TOPMOST );
+		set_win32_foreground_window( getSystemHandle(), HWND_TOP );
 #endif
 
 	if ( m_fes.get_info_bool( FeSettings::MoveMouseOnLaunch ) )

--- a/src/fe_window.hpp
+++ b/src/fe_window.hpp
@@ -41,7 +41,9 @@ protected:
 	void onCreate();
 
 private:
-	sf::Window m_blackout;
+#if defined(SFML_SYSTEM_WINDOWS)
+	sf::RenderWindow m_blackout;
+#endif
 	int m_win_mode;
 
 public:


### PR DESCRIPTION
- Moved Blackout creation before the main window. That eliminates the white flash on launching AM
- Changed fullscreen window style ( explanation of this decission is in the source code)
- Fixed not being able to alt tab to console in FillScreen mode