### PR TITLE
Document all Alignments available in ListBox

### DIFF
--- a/Layouts.md
+++ b/Layouts.md
@@ -1848,6 +1848,17 @@ Properties:
       - `Align.Centre` (default)
       - `Align.Left`
       - `Align.Right`
+      - `Align.TopCentre`
+      - `Align.TopLeft`
+      - `Align.TopRight`
+      - `Align.BottomCentre`
+      - `Align.BottomLeft`
+      - `Align.BottomRight`
+      - `Align.MiddleCentre`
+      - `Align.MiddleLeft`
+      - `Align.MiddleRight`
+     The last 3 alignment modes have the same function as the first 3,
+     but they are more accurate. The first 3 modes are preserved for compatibility.
    * `sel_style` - Get/set the selection text style.  Can be a combination
      of one or more of the following (i.e. `Style.Bold | Style.Italic`):
       - `Style.Regular` (default)


### PR DESCRIPTION
While working on a layout I noticed that the documentation of different Align types for ListBox seems to be out of date, as compared to Text. (And the new types do work in practice as well.)