### PR TITLE
Adding mmal support for Pi 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,11 +326,15 @@ ifneq ($(USE_VC4),1)
  endif
 endif
 
+ifeq ($(USE_MMAL),1)
+ FE_FLAGS += -DUSE_MMAL
+endif
+
 ifeq ($(USE_XLIB),1)
  FE_FLAGS += -DUSE_XLIB
  LIBS += -lX11
 
- ifeq ($(USE_XINERAMA),1)
+ifeq ($(USE_XINERAMA),1)
   FE_FLAGS += -DUSE_XINERAMA
   LIBS += -lXinerama
  endif

--- a/src/media.cpp
+++ b/src/media.cpp
@@ -1467,7 +1467,7 @@ void FeMedia::get_decoder_list( std::vector< std::string > &l )
 
 	l.push_back( "software" );
 
-#ifdef USE_GLES
+#if defined(USE_GLES) || defined(USE_MMAL)
 	//
 	// Raspberry Pi specific - check for mmal
 	//
@@ -1503,7 +1503,7 @@ void FeMedia::try_hw_accel( AVCodecContext *&codec_ctx, AVCodec *&dec )
 	if ( g_decoder.empty() || ( g_decoder.compare( "software" ) == 0 ))
 		return;
 
-#ifdef USE_GLES
+#if defined(USE_GLES) || defined(USE_MMAL)
 	if ( g_decoder.compare( "mmal" ) == 0 )
 	{
 		switch( dec->id )


### PR DESCRIPTION
This commit adds support for mmal on Pi 4 by creating a new preprocessor define and passing it through the makefile. Tested on Pi 4 in Raspian Buster.