### PR TITLE
Fixed frame delay on nested surfaces

### DIFF
--- a/src/fe_present.cpp
+++ b/src/fe_present.cpp
@@ -435,6 +435,7 @@ FeImage *FePresent::add_surface( int w, int h, FePresentableParent &p )
 {
 	FeSurfaceTextureContainer *new_surface = new FeSurfaceTextureContainer( w, h );
 	new_surface->set_smooth( m_feSettings->get_info_bool( FeSettings::SmoothImages ) );
+	new_surface->set_nesting_level( p.get_nesting_level() + 1 );
 
 	//
 	// Set the default sprite size to the same as the texture itself

--- a/src/fe_presentable.cpp
+++ b/src/fe_presentable.cpp
@@ -35,6 +35,15 @@ FeBasePresentable::~FeBasePresentable()
 {
 }
 
+FePresentableParent::FePresentableParent( )
+	: m_nesting_level ( 0 )
+{
+}
+
+FePresentableParent::~FePresentableParent()
+{
+}
+
 void FeBasePresentable::on_new_selection( FeSettings * )
 {
 }
@@ -213,6 +222,16 @@ void FeBasePresentable::set_zorder( int pos )
 
 	std::stable_sort( m_parent.elements.begin(), m_parent.elements.end(), zcompare );
 	FePresent::script_flag_redraw();
+}
+
+int FePresentableParent::get_nesting_level()
+{
+	return m_nesting_level;
+}
+
+void FePresentableParent::set_nesting_level( int p )
+{
+	m_nesting_level = p;
 }
 
 FeImage *FePresentableParent::add_image(const char *n, int x, int y, int w, int h)

--- a/src/fe_presentable.hpp
+++ b/src/fe_presentable.hpp
@@ -110,7 +110,14 @@ class FeListBox;
 class FePresentableParent
 {
 public:
+	FePresentableParent();
+	virtual ~FePresentableParent();
+
 	std::vector< FeBasePresentable * > elements;
+
+	int m_nesting_level;
+	int get_nesting_level();
+	void set_nesting_level( int );
 
 	FeImage *add_image(const char *,int, int, int, int);
 	FeImage *add_image(const char *, int, int);


### PR DESCRIPTION
Added surface sorting. This eliminates the delay in surface content update. For each surface nesting level there was one frame delay. This also works for clones.