### PR TITLE
Added Power Saving toggle

### DIFF
--- a/config/language/en.msg
+++ b/config/language/en.msg
@@ -114,6 +114,7 @@ _help_generator_build;Generate romlist with the selected emulator(s)
 _help_generator_opt;Set whether this emulator is to be included in the generated romlist
 _help_hide_brackets;Hide text in brackets when showing game titles
 _help_hide_console;Hide console on startup. Note that this only works if starting Attract-Mode from a Windows GUI. If started from an existing console window (e.g. a batch file) then the process will always "attach" to the existing console and output to it.
+_help_power_saving;Helps to save power by only redrawing the screen when it's neccessary. May cause animation stuttering on some layouts, or freezing on Linux.
 _help_input_action;
 _help_input_add;Add a new input mapping for this control
 _help_input_default_action;Set the default behaviour for this control

--- a/config/language/msg_template.txt
+++ b/config/language/msg_template.txt
@@ -397,6 +397,7 @@ _help_video_decoder;Configure the decoder to use for video playback (if multiple
 _help_volume;Valid volume settings are from 0 (mute) to 100
 _help_window_mode;Set whether Attract-Mode fills the screen or runs in a window
 _help_hide_console;Hide console on startup. Note that this only works if starting Attract-Mode from a Windows GUI. If started from an existing console window (e.g. a batch file) then the process will always "attach" to the existing console and output to it.
+_help_power_saving;Helps to save power by only redrawing the screen when it's neccessary. May cause animation stuttering on some layouts, or freezing on Linux.
 _sort_regexp;^(Vs\. The |The |Vs\. )
 
 # The next line is needed at the end of the template file

--- a/src/fe_config.cpp
+++ b/src/fe_config.cpp
@@ -2019,6 +2019,12 @@ void FeMiscMenu::get_options( FeConfigContext &ctx )
 	ctx.add_optl( Opt::LIST, "Video Decoder", vid_dec, "_help_video_decoder" );
 	ctx.back_opt().append_vlist( decoders );
 
+	ctx.add_optl( Opt::LIST,
+			"Power Saving",
+			ctx.fe_settings.get_info_bool( FeSettings::PowerSaving ) ? bool_opts[0] : bool_opts[1],
+			"_help_power_saving" );
+	ctx.back_opt().append_vlist( bool_opts );
+
 #ifdef SFML_SYSTEM_WINDOWS
 	ctx.add_optl( Opt::LIST, "Hide Console",
 		ctx.fe_settings.get_hide_console() ? bool_opts[0] : bool_opts[1],
@@ -2072,9 +2078,12 @@ bool FeMiscMenu::save( FeConfigContext &ctx )
 	ctx.fe_settings.set_info( FeSettings::VideoDecoder,
 			ctx.opt_list[13].get_value() );
 
+	ctx.fe_settings.set_info( FeSettings::PowerSaving,
+			ctx.opt_list[14].get_vindex() == 0 ? FE_CFG_YES_STR : FE_CFG_NO_STR );
+
 #ifdef SFML_SYSTEM_WINDOWS
 	ctx.fe_settings.set_info( FeSettings::HideConsole,
-			ctx.opt_list[14].get_vindex() == 0 ? FE_CFG_YES_STR : FE_CFG_NO_STR );
+			ctx.opt_list[15].get_vindex() == 0 ? FE_CFG_YES_STR : FE_CFG_NO_STR );
 #endif
 
 	return true;

--- a/src/fe_overlay.cpp
+++ b/src/fe_overlay.cpp
@@ -900,7 +900,7 @@ void FeOverlay::input_map_dialog(
 		if ( m_fePresent.tick() )
 			redraw = true;
 
-		if ( redraw )
+		if ( redraw || !m_feSettings.get_info_bool( FeSettings::PowerSaving ) )
 		{
 			m_fePresent.redraw_surfaces();
 			m_wnd.clear();
@@ -1422,7 +1422,7 @@ bool FeOverlay::event_loop( FeEventLoopCtx &ctx )
 		if ( m_fePresent.tick() )
 			redraw = true;
 
-		if ( redraw )
+		if ( redraw || !m_feSettings.get_info_bool( FeSettings::PowerSaving ) )
 		{
 			m_fePresent.redraw_surfaces();
 			m_wnd.clear();
@@ -1918,7 +1918,7 @@ bool FeOverlay::edit_loop( std::vector<sf::Drawable *> d,
 		m_wnd.draw( cursor, t );
 		m_wnd.display();
 
-		if ( !redraw )
+		if ( !redraw && m_feSettings.get_info_bool( FeSettings::PowerSaving ) )
 			sf::sleep( sf::milliseconds( 30 ) );
 
 		redraw = false;

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -295,6 +295,7 @@ FeSettings::FeSettings( const std::string &config_path,
 #ifdef SFML_SYSTEM_WINDOWS
 	m_hide_console( false ),
 #endif
+	m_power_saving( false ),
 	m_loaded_game_extras( false ),
 	m_present_state( Layout_Showing )
 {
@@ -423,6 +424,7 @@ const char *FeSettings::configSettingStrings[] =
 	"scrape_videos",
 	"scrape_overview",
 	"thegamesdb_key",
+	"power_saving",
 #ifdef SFML_SYSTEM_WINDOWS
 	"hide_console",
 #endif
@@ -2745,6 +2747,7 @@ const std::string FeSettings::get_info( int index ) const
 	case ScrapeFanArt:
 	case ScrapeVids:
 	case ScrapeOverview:
+	case PowerSaving:
 #ifdef SFML_SYSTEM_WINDOWS
 	case HideConsole:
 #endif
@@ -2802,6 +2805,8 @@ bool FeSettings::get_info_bool( int index ) const
 		return m_scrape_vids;
 	case ScrapeOverview:
 		return m_scrape_overview;
+	case PowerSaving:
+		return m_power_saving;
 #ifdef SFML_SYSTEM_WINDOWS
 	case HideConsole:
 		return m_hide_console;
@@ -3002,6 +3007,10 @@ bool FeSettings::set_info( int index, const std::string &value )
 
 	case ScrapeOverview:
 		m_scrape_overview = config_str_to_bool( value );
+		break;
+
+	case PowerSaving:
+		m_power_saving = config_str_to_bool( value );
 		break;
 
 #ifdef SFML_SYSTEM_WINDOWS

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -131,6 +131,7 @@ public:
 		ScrapeVids,
 		ScrapeOverview,
 		ThegamesdbKey,
+		PowerSaving,
 #ifdef SFML_SYSTEM_WINDOWS
 		HideConsole,
 #endif
@@ -222,6 +223,7 @@ private:
 #ifdef SFML_SYSTEM_WINDOWS
 	bool m_hide_console;
 #endif
+	bool m_power_saving;
 	bool m_loaded_game_extras;
 	enum FePresentState m_present_state;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1056,7 +1056,7 @@ int main(int argc, char *argv[])
 		if ( feVM.saver_activation_check() )
 			soundsys.sound_event( FeInputMap::ScreenSaver );
 
-		if ( redraw )
+		if ( redraw || !feSettings.get_info_bool( FeSettings::PowerSaving ) )
 		{
 			feVM.redraw_surfaces();
 


### PR DESCRIPTION
When it's on it works as before and helps to save power by only redrawing the screen when it's necessary. When off Attract keeps feeding new frames to the frame queue even if there was no change on the screen. It was reported that power saving set to on is causing animation stuttering due to stalling the frame queue and on Linux freezing of the entire application when videos are playing.