### PR TITLE
mmal hw video decoding error detection and reverting to software if error occured

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,10 @@ ifeq ($(USE_MMAL),1)
  FE_FLAGS += -DUSE_MMAL
 endif
 
+ifeq ($(PLATFORM_RPI4),1)
+ FE_FLAGS += -DPLATFORM_RPI4
+endif
+
 ifeq ($(USE_XLIB),1)
  FE_FLAGS += -DUSE_XLIB
  LIBS += -lX11

--- a/Makefile
+++ b/Makefile
@@ -337,10 +337,6 @@ ifeq ($(USE_MMAL),1)
  FE_FLAGS += -DUSE_MMAL
 endif
 
-ifeq ($(PLATFORM_RPI4),1)
- FE_FLAGS += -DPLATFORM_RPI4
-endif
-
 ifeq ($(USE_XLIB),1)
  FE_FLAGS += -DUSE_XLIB
  LIBS += -lX11

--- a/src/media.cpp
+++ b/src/media.cpp
@@ -1513,6 +1513,9 @@ void FeMedia::try_hw_accel( AVCodecContext *&codec_ctx, AVCodec *&dec )
 		case AV_CODEC_ID_MPEG4:
 #if not defined(PLATFORM_RPI4)
 			dec = avcodec_find_decoder_by_name( "mpeg4_mmal" );
+#else
+			FeLog() << "MPEG4 HW video decoding (mpeg4_mmal) not supported on RPI4 for file: " 
+				<< m_imp->m_format_ctx->filename << std::endl;
 #endif
 			return;
 
@@ -1525,12 +1528,18 @@ void FeMedia::try_hw_accel( AVCodecContext *&codec_ctx, AVCodec *&dec )
 		case AV_CODEC_ID_MPEG2VIDEO:
 #if not defined(PLATFORM_RPI4)
 			dec = avcodec_find_decoder_by_name( "mpeg2_mmal" );
+#else
+			FeLog() << "MPEG2 HW video decoding (mpeg2_mmal) not supported on RPI4 for for file: " 
+				<< m_imp->m_format_ctx->filename <<  std::endl;
 #endif
 			return;
 
 		case AV_CODEC_ID_VC1:
 #if not defined(PLATFORM_RPI4)
 			dec = avcodec_find_decoder_by_name( "vc1_mmal" );
+#else
+			FeLog() << "VC1 HW video decoding (vc1_mmal) not supported on RPI4 for file: " 
+				<< m_imp->m_format_ctx->filename <<  std::endl;
 #endif
 			return;
 

--- a/src/media.cpp
+++ b/src/media.cpp
@@ -1508,20 +1508,30 @@ void FeMedia::try_hw_accel( AVCodecContext *&codec_ctx, AVCodec *&dec )
 	{
 		switch( dec->id )
 		{
+			
+
 		case AV_CODEC_ID_MPEG4:
+#if not defined(PLATFORM_RPI4)
 			dec = avcodec_find_decoder_by_name( "mpeg4_mmal" );
+#endif
 			return;
+
 
 		case AV_CODEC_ID_H264:
 			dec = avcodec_find_decoder_by_name( "h264_mmal" );
 			return;
 
+
 		case AV_CODEC_ID_MPEG2VIDEO:
+#if not defined(PLATFORM_RPI4)
 			dec = avcodec_find_decoder_by_name( "mpeg2_mmal" );
+#endif
 			return;
 
 		case AV_CODEC_ID_VC1:
+#if not defined(PLATFORM_RPI4)
 			dec = avcodec_find_decoder_by_name( "vc1_mmal" );
+#endif
 			return;
 
 		default:

--- a/src/media.cpp
+++ b/src/media.cpp
@@ -1054,8 +1054,11 @@ bool FeMedia::open( const std::string &archive,
 
 	if ( m_imp->m_type & Video )
 	{
+		std::string prev_dec_name;
+		int av_result( -1 );
 		int stream_id( -1 );
 		AVCodec *dec;
+
 		stream_id = av_find_best_stream( m_imp->m_format_ctx, AVMEDIA_TYPE_VIDEO,
 					-1, -1, &dec, 0 );
 
@@ -1072,14 +1075,46 @@ bool FeMedia::open( const std::string &archive,
 			// Note also: http://trac.ffmpeg.org/ticket/4404
 			codec_ctx->thread_count=1;
 
+			if (dec)
+				prev_dec_name = std::string(dec->name);
+
 			try_hw_accel( codec_ctx, dec );
 
-			if ( avcodec_open2( codec_ctx, dec, NULL ) < 0 )
+			av_result = avcodec_open2( codec_ctx, dec, NULL );
+			if ( av_result < 0 )
 			{
-				FeLog() << "Could not open video decoder for file: "
-					<< m_imp->m_format_ctx->filename << std::endl;
+				if ( !prev_dec_name.empty() && (g_decoder.compare( "mmal" ) == 0) )
+				{ 
+					switch( dec->id )
+					{
+
+
+					case AV_CODEC_ID_VC1:
+					case AV_CODEC_ID_MPEG2VIDEO:
+					case AV_CODEC_ID_H264:
+					case AV_CODEC_ID_MPEG4:
+						FeLog() << "mmal video decoding (" << dec->name 
+							<< ") not supported for file (trying software): " 
+							<< m_imp->m_format_ctx->filename << std::endl;
+
+						dec = avcodec_find_decoder_by_name(prev_dec_name.c_str());
+
+						av_result = avcodec_open2( codec_ctx, dec, NULL );
+						break;
+						
+					default:
+						break;
+					}
+				}
+
+				if ( av_result < 0 )
+				{
+					FeLog() << "Could not open video decoder for file: "
+							<< m_imp->m_format_ctx->filename << std::endl;
+				}
 			}
-			else
+
+			if ( av_result >=0  )
 			{
 				m_video = new FeVideoImp( this );
 				m_video->stream_id = stream_id;
@@ -1508,15 +1543,9 @@ void FeMedia::try_hw_accel( AVCodecContext *&codec_ctx, AVCodec *&dec )
 	{
 		switch( dec->id )
 		{
-			
 
 		case AV_CODEC_ID_MPEG4:
-#if not defined(PLATFORM_RPI4)
 			dec = avcodec_find_decoder_by_name( "mpeg4_mmal" );
-#else
-			FeLog() << "MPEG4 HW video decoding (mpeg4_mmal) not supported on RPI4 for file: " 
-				<< m_imp->m_format_ctx->filename << std::endl;
-#endif
 			return;
 
 
@@ -1526,21 +1555,11 @@ void FeMedia::try_hw_accel( AVCodecContext *&codec_ctx, AVCodec *&dec )
 
 
 		case AV_CODEC_ID_MPEG2VIDEO:
-#if not defined(PLATFORM_RPI4)
 			dec = avcodec_find_decoder_by_name( "mpeg2_mmal" );
-#else
-			FeLog() << "MPEG2 HW video decoding (mpeg2_mmal) not supported on RPI4 for for file: " 
-				<< m_imp->m_format_ctx->filename <<  std::endl;
-#endif
 			return;
 
 		case AV_CODEC_ID_VC1:
-#if not defined(PLATFORM_RPI4)
 			dec = avcodec_find_decoder_by_name( "vc1_mmal" );
-#else
-			FeLog() << "VC1 HW video decoding (vc1_mmal) not supported on RPI4 for file: " 
-				<< m_imp->m_format_ctx->filename <<  std::endl;
-#endif
 			return;
 
 		default:


### PR DESCRIPTION
fixes #625 by specifying PLATFORM_RPI4=1 when making and not using mmal for mpeg4 / 2 & vc1 as it's not supported on the pi4 .

I explictly did not use a detection for RPI4 as i don't know how and it might break crosscompiling. If people also omit PLATFORM_RPI4=1 on the make line it will just compile as before but breaks mpeg4 / 2 & vc1 videoplay back as it's not supported on pi4.

Also don't know if you would have had me rather changing the USE_MMAL define instead of creating the PLATFORM_RPI4 one but i guess if there are other specifics to RPI4 it could be reused

sorry did not know how to fix my repo / branch without doing new PR, now it's not showing a merge commit