### PR TITLE
Added a new compile flag ALLOW_SSH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,12 @@
 # decoding on Linux (req FFmpeg >= 3.4)
 #FE_HWACCEL_VAAPI=1
 #FE_HWACCEL_VDPAU=1
+#
+# Uncomment the next line to allow Attract-Mode to be launched from the
+# SSH session. Please be aware that when Attract-Mode is launched from the
+# remote session there is a danger of unknowingly enter shell commands into
+# the non busy console underneath when hardwired keyboard device is used.
+#ALLOW_SSH=1
 ###############################
 
 #FE_DEBUG=1
@@ -351,6 +357,10 @@ endif
 ifeq ($(USE_DRM),1)
  TEMP_LIBS += libdrm gbm
  FE_FLAGS += -DUSE_DRM
+endif
+
+ifeq ($(ALLOW_SSH),1)
+  FE_FLAGS += -DALLOW_SSH
 endif
 
 ifeq ($(FE_HWACCEL_VAAPI),1)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,6 +109,14 @@ int main(int argc, char *argv[])
 	fe_print_version();
 	FeLog() << std::endl;
 
+#ifndef ALLOW_SSH
+	if( std::getenv("SSH_CLIENT") || std::getenv("SSH_TTY"))
+	{
+		FeLog() << "SSH session detected. Please run Attract-Mode from the device you're connected to.\n";
+		return 0;
+	}
+#endif
+
 #ifdef SFML_SYSTEM_WINDOWS
 	// Detect an nvidia card and if it's found create an nvidia profile
 	// for Attract Mode with optimizations


### PR DESCRIPTION
When this flag is set Attract-Mode can be launched from the SSH session. It's set by default to off. When Attract-Mode is launched from the remote session there is a danger of unknowingly enter shell commands into the non busy console underneath when hardwired keyboard device is used.