### PR TITLE
fix xinerama dimensions in windowed mode

### DIFF
--- a/src/fe_present.cpp
+++ b/src/fe_present.cpp
@@ -363,8 +363,8 @@ void FePresent::init_monitors()
 			{
 				FeMonitor mon(
 					si[0].screen_number,
-					si[0].width,
-					si[0].height );
+					m_window.get_win().getSize().x,
+					m_window.get_win().getSize().y);
 
 				m_mon.push_back( mon );
 			}


### PR DESCRIPTION
When using windowed mode on Linux, the dimension is not calculated correctly resulting in layouts being stretched outside of the viewable area. Typically I set dimensions in the am file to test vertical / cga sizes.