### PR TITLE
Include  libxrandr-dev in Build-Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: games
 Priority: optional
 Maintainer: Andrew Mickelson <andrew@attractmode.org>
 Build-Depends: debhelper (>= 9), pkgconf, git,
- libarchive-dev, libavcodec-dev, libavformat-dev, libavresample-dev,
+ libarchive-dev, libavcodec-dev, libavformat-dev, libswresample-dev,
  libavutil-dev, libfontconfig-dev, libfreetype6-dev, libglu-dev,
  libjpeg62-turbo-dev | libjpeg-turbo8-dev,
  libxrandr-dev, libopenal-dev, libsfml-dev, libswscale-dev, libxinerama-dev,

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 9), pkgconf, git,
  libarchive-dev, libavcodec-dev, libavformat-dev, libavresample-dev,
  libavutil-dev, libfontconfig-dev, libfreetype6-dev, libglu-dev,
  libjpeg62-turbo-dev | libjpeg-turbo8-dev,
- libopenal-dev, libsfml-dev, libswscale-dev, libxinerama-dev,
+ libxrandr-dev, libopenal-dev, libsfml-dev, libswscale-dev, libxinerama-dev,
  libcurl4-openssl-dev | libcurl4-nss-dev | libcurl4-gnutls-dev
 Standards-Version: 3.9.5
 Homepage: http://attractmode.org


### PR DESCRIPTION
sbuild fails with
```
Compiling obj/fe_present.o...
src/fe_present.cpp:42:10: fatal error: X11/extensions/Xrandr.h: No such file or directory
   42 | #include <X11/extensions/Xrandr.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [Makefile:486: obj/fe_present.o] Error 1
```