### PR TITLE
Fix build issue with recent ffmpeg

### DIFF
--- a/src/media.cpp
+++ b/src/media.cpp
@@ -145,7 +145,7 @@ public:
 	bool at_end;					// set when at the end of our input
 	bool far_behind;
 	AVCodecContext *codec_ctx;
-	AVCodec *codec;
+	const AVCodec *codec;
 	int stream_id;
 
 	FeBaseStream();
@@ -1061,7 +1061,7 @@ bool FeMedia::open( const std::string &archive,
 	if ( m_imp->m_type & Audio )
 	{
 		int stream_id( -1 );
-		AVCodec *dec;
+		const AVCodec *dec;
 		stream_id = av_find_best_stream( m_imp->m_format_ctx, AVMEDIA_TYPE_AUDIO,
 			-1, -1, &dec, 0 );
 
@@ -1119,7 +1119,7 @@ bool FeMedia::open( const std::string &archive,
 		std::string prev_dec_name;
 		int av_result( -1 );
 		int stream_id( -1 );
-		AVCodec *dec;
+		const AVCodec *dec;
 
 		stream_id = av_find_best_stream( m_imp->m_format_ctx, AVMEDIA_TYPE_VIDEO,
 					-1, -1, &dec, 0 );
@@ -1481,7 +1481,7 @@ void FeMedia::set_current_decoder( const std::string &l )
 //
 // Try to use a hardware accelerated decoder where readily available...
 //
-void FeMedia::try_hw_accel( AVCodecContext *&codec_ctx, AVCodec *&dec )
+void FeMedia::try_hw_accel( AVCodecContext *&codec_ctx, const AVCodec *&dec )
 {
 	if ( g_decoder.empty() || ( g_decoder.compare( "software" ) == 0 ))
 		return;

--- a/src/media.hpp
+++ b/src/media.hpp
@@ -110,7 +110,7 @@ protected:
 	bool read_packet();
 	bool end_of_file();
 
-	void try_hw_accel( AVCodecContext *& ctx, AVCodec *&dec );
+	void try_hw_accel( AVCodecContext *& ctx, const AVCodec *&dec );
 
 private:
 	FeMediaImp *m_imp;


### PR DESCRIPTION
Recent versions of ffmpeg expect a `const AVCodec **` type for `av_find_best_stream` (e.g. see https://ffmpeg.org/doxygen/trunk/group__lavf__decoding.html#ga8d4609a8f685ad894c1503ffd1b610b4). Without this change the build fails with:
```
src/media.cpp: In member function ‘bool FeMedia::open(const std::string&, const std::string&, sf::Texture*)’:
src/media.cpp:1066:33: error: invalid conversion from ‘AVCodec**’ to ‘const AVCodec**’ [-fpermissive]
 1066 |                         -1, -1, &dec, 0 );
      |                                 ^~~~
      |                                 |
      |                                 AVCodec**
```
Tested with ffmpeg 5.0 on Linux.