### PR TITLE
Fix string out of bounds access issue

### DIFF
--- a/src/tp.cpp
+++ b/src/tp.cpp
@@ -205,6 +205,7 @@ void FeTextPrimative::fit_string(
 		{
 			i--;
 			last_char = i - 1;
+			if ( last_char < 0 ) last_char = 0;
 			if ( s[last_char] == L' ' ) last_char--;
 		}
 		else


### PR DESCRIPTION
`last_char` can become negative here, which can result in attempting to index the string at an invalid position, which leads to
```
/usr/include/c++/12/bits/basic_string.h:1201: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::const_reference std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::operator[](size_type) const [with _CharT = unsigned int; _Traits = std::char_traits<unsigned int>; _Alloc = std::allocator<unsigned int>; const_reference = const unsigned int&; size_type = long unsigned int]: Assertion '__pos <= size()' failed.
Aborted (core dumped)
```