### PR TITLE
Fix build with USE_DRM=1

### DIFF
--- a/src/fe_present.cpp
+++ b/src/fe_present.cpp
@@ -56,6 +56,7 @@
 #include <stdio.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
+#include <string.h>
 #endif
 
 #ifdef SFML_SYSTEM_MACOS


### PR DESCRIPTION
`USE_DRM` needs a `memset` declaration, include `string.h` to get it.

Otherwise, the build fails with:
```
make USE_DRM=1
....
Compiling obj/fe_present.o...
src/fe_present.cpp: In member function ‘void FePresent::init_monitors()’:
src/fe_present.cpp:273:5: error: ‘memset’ was not declared in this scope
     memset( &mode_info, 0, sizeof( drmModeModeInfo ));
     ^~~~~~
...
```