### PR TITLE
Fix for cross-platform mxe build.

### DIFF
--- a/src/stb_image.h
+++ b/src/stb_image.h
@@ -385,7 +385,7 @@ typedef unsigned char stbi_uc;
 typedef unsigned short stbi_us;
 
 #ifdef __cplusplus
-extern "C" {
+//extern "C" {
 #endif
 
 #ifndef STBIDEF
@@ -533,7 +533,7 @@ STBIDEF int   stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const ch
 
 
 #ifdef __cplusplus
-}
+//}
 #endif
 
 //


### PR DESCRIPTION
Build fix for conflict with mxe's libsfml-graphics. I noticed that the previous version of this file had the extern commented out so I just did the same.