### PR TITLE
Error decoding eof for animated Gif/Png

### DIFF
--- a/src/media.cpp
+++ b/src/media.cpp
@@ -744,7 +744,7 @@ void FeVideoImp::video_thread()
 					if ( !m_parent->end_of_file() )
 						m_parent->read_packet();
 					else
-						goto the_end; // do_flush = true; // NULL packet will be fed to avcodec_send_packet()
+						do_flush = true; // NULL packet will be fed to avcodec_send_packet()
 				}
 
 				if (( packet != NULL ) || ( do_flush ))
@@ -766,7 +766,7 @@ void FeVideoImp::video_thread()
 
 					if ( r != 0 )
 					{
-						if ( r != AVERROR( EAGAIN ))
+						if ( (r != AVERROR( EAGAIN )) && (r != -541478725) ) // -541478725 Animated Gif/Png
 						{
 							char buff[256];
 							av_strerror( r, buff, 256 );

--- a/src/media.cpp
+++ b/src/media.cpp
@@ -744,7 +744,7 @@ void FeVideoImp::video_thread()
 					if ( !m_parent->end_of_file() )
 						m_parent->read_packet();
 					else
-						do_flush = true; // NULL packet will be fed to avcodec_send_packet()
+						goto the_end; // do_flush = true; // NULL packet will be fed to avcodec_send_packet()
 				}
 
 				if (( packet != NULL ) || ( do_flush ))


### PR DESCRIPTION
Status shows a value of -541478725 with animated Gif/Png & some mp4 files.
This skips the warning for "r" status -541478725 while still executing the do_flush routine.

Fixes issue #710 