### PR TITLE
Ignore EOF on do_flush

### DIFF
--- a/src/media.cpp
+++ b/src/media.cpp
@@ -766,7 +766,7 @@ void FeVideoImp::video_thread()
 
 					if ( r != 0 )
 					{
-						if ( r != AVERROR( EAGAIN ))
+						if (( r != AVERROR( EAGAIN )) && (!do_flush)) // Ignore EOF on do_flush
 						{
 							char buff[256];
 							av_strerror( r, buff, 256 );


### PR DESCRIPTION
Ignore the EOF warning when calling avcodec_receive_frame while do_flush is executing.
An EOF warning ocures with animated gif/png & h264 (encoded as lossless) when next packet is NULL and do_flush is initiated.
I suspect this is due to frames being stored rather than encoded and there are no more frames to retrieve in the pipeline after the NULL packet.