### PR TITLE
Support roms in subdirectories

### DIFF
--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -2247,6 +2247,7 @@ void FeSettings::prep_for_launch( std::string &command,
 	for ( itr = paths.begin(); itr != paths.end(); ++itr )
 	{
 		std::string path = emu->clean_path_with_wd( *itr, true );
+		perform_substitution( path, "[name]", rom_name );
 
 		std::vector < std::string > in_list;
 		std::vector < std::string > out_list;


### PR DESCRIPTION
Allows use of [name] in rompath. This is necessary when using subdirectories and multiple extensions are in use. I tried using \<DIR> extension, but this would only allow use of one extension. For example it would work with .cue, but I couldn't also use .m3u for multi-disc games.

This submission will replace [name] with the romname in the path. I added logging before and after to confirm the substitution. 

First here's relevant lines from emulator file:
```
executable           retroarch
args                 --fullscreen -L mednafen_psx_libretro.so "[romfilename]"
rompath              $HOME/roms/psx/[name]
```
Console output when launch .cue with logging:
```
Path Before: /home/user/roms/psx/[name]/
Path After: /home/user/roms/psx/Adventures of Lomax, The (USA)/
*** Running: retroarch --fullscreen -L mednafen_psx_libretro.so "/home/user/roms/psx/Adventures of Lomax, The (USA)/Adventures of Lomax, The (USA).cue"
```

Console output when launch .m3u with logging:
```
Path Before: /home/user/roms/psx/[name]/
Path After: /home/user/roms/psx/Final Fantasy IX (USA)/
*** Running: retroarch --fullscreen -L mednafen_psx_libretro.so "/home/user/roms/psx/Final Fantasy IX (USA)/Final Fantasy IX (USA).m3u"
```

I know I'm not the only one to run into this issue. This was also discussed on the [forum](http://forum.attractmode.org/index.php?topic=1279.0)