### PR TITLE
Run exit_command at end of main()

### DIFF
--- a/src/fe_overlay.cpp
+++ b/src/fe_overlay.cpp
@@ -1963,10 +1963,7 @@ bool FeOverlay::edit_loop( std::vector<sf::Drawable *> d,
 bool FeOverlay::common_exit()
 {
 	if ( !m_feSettings.get_info_bool( FeSettings::ConfirmExit ) )
-	{
-		m_feSettings.exit_command();
 		return true;
-	}
 
 	std::string exit_msg;
 	m_feSettings.get_exit_question( exit_msg );
@@ -1977,13 +1974,5 @@ bool FeOverlay::common_exit()
 	// retval is 0 if the user confirmed exit.
 	// it is <0 if we are being forced to close
 	//
-	if ( retval < 1 )
-	{
-		if ( retval == 0 )
-			m_feSettings.exit_command();
-
-		return true;
-	}
-
-	return false;
+	return ( retval < 1 );
 }

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -2393,7 +2393,7 @@ bool FeSettings::update_stats( int play_count, int play_time )
 
 int FeSettings::exit_command() const
 {
-	int r( -1 );
+	int r( 0 );
 	if ( !m_exit_command.empty() )
 		r = system( m_exit_command.c_str() );
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1118,5 +1118,5 @@ int main(int argc, char *argv[])
 #endif
 
 	FeDebug() << "Attract-Mode ended normally" << std::endl;
-	return 0;
+	return feSettings.exit_command();
 }


### PR DESCRIPTION
The exit command can cause Attract-Mode to be terminated by the operating system before it can gracefully exit on its own, such as when the exit command shuts down the system.  In particular, feSettings.save_state() may get skipped or aborted with a half- written attract.am.

Instead, run the exit command as the final act of main() after exiting the main loop and cleaning up resources.  And pass the command's exit code through as Attract-Mode's exit code.