### PR TITLE
Fix missing include

### DIFF
--- a/src/fe_net.hpp
+++ b/src/fe_net.hpp
@@ -27,6 +27,7 @@
 #include <thread>
 #include <deque>
 #include <queue>
+#include <string>
 
 class FeNetWorker;
 


### PR DESCRIPTION
During the removal of the line `#include <SFML/System.hpp>` as part of 7cb8d58130b9e32e6c75320c314d6f8c307ea9f5, it looks like there was a necessary transitive include that was removed. Adding that transitive include in to fix compilation errors.