### PR TITLE
Improve mouse navigation in overlay menus

### DIFF
--- a/src/fe_overlay.cpp
+++ b/src/fe_overlay.cpp
@@ -1390,6 +1390,15 @@ bool FeOverlay::event_loop( FeEventLoopCtx &ctx )
 					&& ( c == ctx.extra_exit ))
 				c = FeInputMap::Exit;
 
+			if ( ev.type == sf::Event::MouseMoved )
+			{
+				if ( m_feSettings.test_mouse_reset( ev.mouseMove.x, ev.mouseMove.y ) )
+				{
+					sf::Vector2u s = m_wnd.get_win().getSize();
+					sf::Mouse::setPosition( sf::Vector2i( s.x / 2, s.y / 2 ), m_wnd.get_win() );
+				}
+			}
+
 			switch( c )
 			{
 			case FeInputMap::Back:
@@ -1407,7 +1416,7 @@ bool FeOverlay::event_loop( FeEventLoopCtx &ctx )
 
 				if ( ctx.sel > 0 )
 					ctx.sel--;
-				else
+				else if ( ev.type != sf::Event::MouseMoved )
 					ctx.sel=ctx.max_sel;
 
 				ctx.move_event = ev;
@@ -1423,7 +1432,7 @@ bool FeOverlay::event_loop( FeEventLoopCtx &ctx )
 
 				if ( ctx.sel < ctx.max_sel )
 					ctx.sel++;
-				else
+				else if ( ev.type != sf::Event::MouseMoved )
 					ctx.sel = 0;
 
 				ctx.move_event = ev;


### PR DESCRIPTION
Two changes to `FeOverlay::event_loop()`:

- In the event of a mouse move, reset the mouse position to the middle of the window if it strays outside the mouse capture area.

- Do not wrap around the selected menu item if the first or last menu item was reached by a mouse move event.

This makes overlay menus easier to navigate using a trackball or rotary spinner that presents as a mouse device.

**Additional context:**

I use Attract-Mode in a cocktail-style arcade cabinet with swappable control panels.  For panels where the only directional control is a trackball or rotary spinner, I have Attract-Mode's input map configured to include **Mouse Up** for up and **Mouse Down** for down:
```
$ cat ~/.attract/attract.cfg
...
input_map
        ...
        up                   Up
        up                   R
        up                   Mouse Up
        down                 Down
        down                 F
        down                 Mouse Down
        ...
```
But mouse navigation in the overlay menus -- even just the exit confirmation dialog -- has been quite difficult.  Mouse movement is erratic and hard to control with any precision.  This pull request attempts to fix it.