### PR TITLE
Build Objective-C++ files with the C++ compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -508,7 +508,7 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp $(DEP) | $(OBJ_DIR)
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.mm $(DEP) | $(OBJ_DIR)
 	$(CC_MSG)
-	$(SILENT)$(CC) -c -o $@ $< $(CFLAGS) $(CPPFLAGS) $(FE_FLAGS)
+	$(SILENT)$(CXX) -c -o $@ $< $(CXXFLAGS) $(CPPFLAGS) $(FE_FLAGS)
 
 $(EXE): $(OBJ) $(EXPAT) $(SQUIRREL) $(AUDIO)
 	$(EXE_MSG)


### PR DESCRIPTION
This was required to get the build working on macOS in Nixpkgs for me.