### PR TITLE
Port to SFML 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ UNAME_S := $(shell uname -s)
 CC=gcc
 CXX=g++
 CFLAGS=
-CXXFLAGS=-std=c++11 $(EXTRA_CXXFLAGS)
+CXXFLAGS=-std=c++17 $(EXTRA_CXXFLAGS)
 CPPFLAGS=
 STRIP=strip
 OBJCOPY=objcopy
@@ -91,7 +91,7 @@ WINDRES=windres
 ifeq ($(UNAME_S),FreeBSD)
 CC=clang
 CXX=clang++
-CXXFLAGS=-std=c++14 $(EXTRA_CXXFLAGS)
+CXXFLAGS=-std=c++17 $(EXTRA_CXXFLAGS)
 PKG_CONFIG=pkgconf
 NO_SWF=1
 endif

--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,9 @@ ifeq ($(WINDOWS_STATIC),1)
  CPPFLAGS += -DSFML_STATIC $(shell $(PKG_CONFIG) --static --cflags $(SFML_PC))
  FE_WINDOWS_COMPILE=1
 
+else ifeq ($(shell $(PKG_CONFIG) --exists sfml-all && echo "1" || echo "0"), 1)
+  TEMP_LIBS += sfml-all
+  CPPFLAGS += $(shell $(PKG_CONFIG) --cflags sfml-all)
 else
   TEMP_LIBS += sfml-graphics sfml-window sfml-system
 endif
@@ -459,6 +462,7 @@ endif
 CPPFLAGS += -D__STDC_CONSTANT_MACROS
 
 LIBS := $(LIBS) $(shell $(PKG_CONFIG) --libs $(TEMP_LIBS))
+LIBS += -lbz2 -lcrypto -lzstd -llz4 -llzma -lacl
 CPPFLAGS := $(CPPFLAGS) $(shell $(PKG_CONFIG) --cflags $(TEMP_LIBS))
 
 EXE = $(EXE_BASE)$(EXE_EXT)

--- a/extlibs/audio/Audio/SoundStream.cpp
+++ b/extlibs/audio/Audio/SoundStream.cpp
@@ -30,7 +30,6 @@
 #include <Audio/ALCheck.hpp>
 #include <SFML/System/Sleep.hpp>
 #include <SFML/System/Err.hpp>
-#include <SFML/System/Lock.hpp>
 
 #ifdef _MSC_VER
     #pragma warning(disable : 4355) // 'this' used in base member initializer list
@@ -62,7 +61,8 @@ SoundStream::~SoundStream()
     m_isStreaming = false;
 
     // Wait for the thread to terminate
-    m_thread.wait();
+    if (m_thread.joinable())
+        m_thread.join();
 }
 
 
@@ -108,7 +108,6 @@ void SoundStream::play()
     // Start updating the stream in a separate thread to avoid blocking the application
     m_samplesProcessed = 0;
     m_isStreaming = true;
-    m_thread.launch();
 }
 
 
@@ -124,7 +123,8 @@ void SoundStream::stop()
 {
     // Wait for the thread to terminate
     m_isStreaming = false;
-    m_thread.wait();
+    if (m_thread.joinable())
+        m_thread.join();
 }
 
 void SoundStream::signal_stop()
@@ -169,9 +169,8 @@ void SoundStream::setPlayingOffset(Time timeOffset)
     onSeek(timeOffset);
 
     // Restart streaming
-    m_samplesProcessed = static_cast<Uint64>(timeOffset.asSeconds() * m_sampleRate * m_channelCount);
+    m_samplesProcessed = static_cast<std::uint64_t>(timeOffset.asSeconds() * m_sampleRate * m_channelCount);
     m_isStreaming = true;
-    m_thread.launch();
 }
 
 
@@ -333,7 +332,7 @@ bool SoundStream::fillAndPushBuffer(unsigned int bufferNum)
         unsigned int buffer = m_buffers[bufferNum];
 
         // Fill the buffer
-        ALsizei size = static_cast<ALsizei>(data.sampleCount) * sizeof(Int16);
+        ALsizei size = static_cast<ALsizei>(data.sampleCount) * sizeof(std::int16_t);
         alCheck(alBufferData(buffer, m_format, data.samples, size, m_sampleRate));
 
         // Push it into the sound queue

--- a/extlibs/audio/include/Audio/SoundStream.hpp
+++ b/extlibs/audio/include/Audio/SoundStream.hpp
@@ -29,8 +29,9 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <Audio/SoundSource.hpp>
-#include <SFML/System/Thread.hpp>
 #include <SFML/System/Time.hpp>
+#include <thread>
+#include <cstdint>
 #include <cstdlib>
 
 
@@ -50,7 +51,7 @@ public :
     ////////////////////////////////////////////////////////////
     struct Chunk
     {
-        const Int16* samples;     ///< Pointer to the audio samples
+        const std::int16_t* samples;     ///< Pointer to the audio samples
         std::size_t  sampleCount; ///< Number of samples pointed by Samples
     };
 
@@ -281,14 +282,14 @@ private :
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    Thread        m_thread;                  ///< Thread running the background tasks
+    std::thread   m_thread;                  ///< Thread running the background tasks
     bool          m_isStreaming;             ///< Streaming state (true = playing, false = stopped)
     unsigned int  m_buffers[BufferCount];    ///< Sound buffers used to store temporary audio data
     unsigned int  m_channelCount;            ///< Number of channels (1 = mono, 2 = stereo, ...)
     unsigned int  m_sampleRate;              ///< Frequency (samples / second)
-    Uint32        m_format;                  ///< Format of the internal sound buffers
+    std::uint32_t m_format;                  ///< Format of the internal sound buffers
     bool          m_loop;                    ///< Loop flag (true to loop, false to play once)
-    Uint64        m_samplesProcessed;        ///< Number of buffers processed since beginning of the stream
+    std::uint64_t m_samplesProcessed;        ///< Number of buffers processed since beginning of the stream
     bool          m_endBuffers[BufferCount]; ///< Each buffer is marked as "end buffer" or not, for proper duration calculation
 };
 

--- a/src/fe_blend.cpp
+++ b/src/fe_blend.cpp
@@ -60,19 +60,19 @@ sf::BlendMode FeBlend::get_blend_mode( int blend_mode )
 
 #if ( SFML_VERSION_INT >= FE_VERSION_INT( 2, 4, 0 ))
 		case FeBlend::Subtract:
-			return sf::BlendMode(sf::BlendMode::SrcAlpha, sf::BlendMode::One, sf::BlendMode::ReverseSubtract,
-								 sf::BlendMode::One, sf::BlendMode::One, sf::BlendMode::ReverseSubtract);
+			return sf::BlendMode(sf::BlendMode::Factor::SrcAlpha, sf::BlendMode::Factor::One, sf::BlendMode::Equation::ReverseSubtract,
+								 sf::BlendMode::Factor::One, sf::BlendMode::Factor::One, sf::BlendMode::Equation::ReverseSubtract);
 #endif
 
 #if ( SFML_VERSION_INT >= FE_VERSION_INT( 2, 2, 0 ))
 		case FeBlend::Screen:
-			return sf::BlendMode(sf::BlendMode::One, sf::BlendMode::OneMinusSrcColor);
+			return sf::BlendMode(sf::BlendMode::Factor::One, sf::BlendMode::Factor::OneMinusSrcColor);
 		case FeBlend::Multiply:
-			return sf::BlendMode(sf::BlendMode::DstColor, sf::BlendMode::OneMinusSrcAlpha);
+			return sf::BlendMode(sf::BlendMode::Factor::DstColor, sf::BlendMode::Factor::OneMinusSrcAlpha);
 		case FeBlend::Overlay:
-			return sf::BlendMode(sf::BlendMode::DstColor, sf::BlendMode::SrcColor);
+			return sf::BlendMode(sf::BlendMode::Factor::DstColor, sf::BlendMode::Factor::SrcColor);
 		case FeBlend::Premultiplied:
-			return sf::BlendMode(sf::BlendMode::One, sf::BlendMode::OneMinusSrcAlpha);
+			return sf::BlendMode(sf::BlendMode::Factor::One, sf::BlendMode::Factor::OneMinusSrcAlpha);
 #endif
 
 		case FeBlend::None:
@@ -101,21 +101,21 @@ sf::Shader* FeBlend::get_default_shader( int blend_mode )
 			if ( !default_shader_multiplied )
 			{
 				default_shader_multiplied = new sf::Shader();
-				default_shader_multiplied->loadFromMemory( DEFAULT_SHADER_GLSL_MULTIPLIED, sf::Shader::Fragment );
+				default_shader_multiplied->loadFromMemory( DEFAULT_SHADER_GLSL_MULTIPLIED, sf::Shader::Type::Fragment );
 			}
 			return default_shader_multiplied;
 		case FeBlend::Overlay:
 			if ( !default_shader_overlay )
 			{
 				default_shader_overlay = new sf::Shader();
-				default_shader_overlay->loadFromMemory( DEFAULT_SHADER_GLSL_OVERLAY, sf::Shader::Fragment );
+				default_shader_overlay->loadFromMemory( DEFAULT_SHADER_GLSL_OVERLAY, sf::Shader::Type::Fragment );
 			}
 			return default_shader_overlay;
 		case FeBlend::Premultiplied:
 			if ( !default_shader_premultiplied )
 			{
 				default_shader_premultiplied = new sf::Shader();
-				default_shader_premultiplied->loadFromMemory( DEFAULT_SHADER_GLSL_PREMULTIPLIED, sf::Shader::Fragment );
+				default_shader_premultiplied->loadFromMemory( DEFAULT_SHADER_GLSL_PREMULTIPLIED, sf::Shader::Type::Fragment );
 			}
 			return default_shader_premultiplied;
 		default:

--- a/src/fe_file.cpp
+++ b/src/fe_file.cpp
@@ -35,45 +35,47 @@ FeFileInputStream::~FeFileInputStream()
 		fclose( m_file );
 }
 
-sf::Int64 FeFileInputStream::read( void *data, sf::Int64 size )
+std::optional<std::size_t> FeFileInputStream::read( void *data, std::size_t size )
 {
 	if ( m_file )
-		return fread( data, 1, (size_t)size, m_file );
+		return fread( data, 1, size, m_file );
 
-	return -1;
+	return std::nullopt;
 }
 
-sf::Int64 FeFileInputStream::seek( sf::Int64 pos )
+std::optional<std::size_t> FeFileInputStream::seek( std::size_t pos )
 {
 	if ( m_file )
 	{
-		if ( fseek( m_file, (size_t)pos, SEEK_SET ) )
-			return -1;
+		if ( fseek( m_file, (long)pos, SEEK_SET ) )
+			return std::nullopt;
 
 		return tell();
 	}
 
-	return -1;
+	return std::nullopt;
 }
 
-sf::Int64 FeFileInputStream::tell()
+std::optional<std::size_t> FeFileInputStream::tell()
 {
 	if ( m_file )
 		return ftell( m_file );
 
-	return -1;
+	return std::nullopt;
 }
 
-sf::Int64 FeFileInputStream::getSize()
+std::optional<std::size_t> FeFileInputStream::getSize()
 {
 	if ( m_file )
 	{
-		sf::Int64 pos = tell();
+		auto pos = tell();
+		if (pos == std::nullopt)
+			return std::nullopt;
 		fseek( m_file, 0, SEEK_END );
-		sf::Int64 size = tell();
-		seek( pos );
+		auto size = tell();
+		seek(*pos);
 		return size;
 	}
 
-	return -1;
+	return std::nullopt;
 }

--- a/src/fe_file.hpp
+++ b/src/fe_file.hpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <SFML/System/InputStream.hpp>
 #include <cstdio>
+#include <cstdint>
 
 class FeFileInputStream : public sf::InputStream
 {
@@ -33,10 +34,10 @@ public:
 	FeFileInputStream( const std::string &fn );
 	~FeFileInputStream();
 
-	sf::Int64 read( void *data, sf::Int64 size );
-	sf::Int64 seek( sf::Int64 pos );
-	sf::Int64 tell();
-	sf::Int64 getSize();
+	std::optional<std::size_t> read( void *data, std::size_t size ) override;
+	std::optional<std::size_t> seek( std::size_t pos ) override;
+	std::optional<std::size_t> tell() override;
+	std::optional<std::size_t> getSize() override;
 
 private:
 	FILE *m_file;

--- a/src/fe_image.cpp
+++ b/src/fe_image.cpp
@@ -301,7 +301,7 @@ bool FeTextureContainer::fix_masked_image()
 
 	if (( tmp_s.x > 0 ) && ( tmp_s.y > 0 ))
 	{
-		sf::Color p = tmp_img.getPixel( 0, 0 );
+		sf::Color p = tmp_img.getPixel( sf::Vector2u(0, 0) );
 		tmp_img.createMaskFromColor( p );
 
 		if ( m_texture.loadFromImage( tmp_img ) )
@@ -523,7 +523,7 @@ bool FeTextureContainer::try_to_load(
 
 	// resize our texture accordingly
 	if ( m_texture.getSize() != sf::Vector2u( m_entry->get_width(), m_entry->get_height() ) )
-		m_texture.create( m_entry->get_width(), m_entry->get_height() );
+		m_texture.resize( sf::Vector2u( m_entry->get_width(), m_entry->get_height() ) );
 
 	if ( data )
 	{
@@ -1082,7 +1082,7 @@ void FeTextureContainer::release_audio( bool state )
 FeSurfaceTextureContainer::FeSurfaceTextureContainer( int width, int height )
 	: m_clear( true )
 {
-	m_texture.create( width, height );
+	m_texture.resize( sf::Vector2u( width, height ) );
 }
 
 FeSurfaceTextureContainer::~FeSurfaceTextureContainer()
@@ -1240,7 +1240,7 @@ void FeImage::texture_changed( FeBaseTextureContainer *new_tex )
 
 	//  reset texture rect now to the one reported by the new texture object
 	m_sprite.setTextureRect(
-		sf::IntRect( 0, 0, m_tex->get_texture().getSize().x, m_tex->get_texture().getSize().y ) );
+		sf::IntRect({0, 0}, {static_cast<int>(m_tex->get_texture().getSize().x), static_cast<int>(m_tex->get_texture().getSize().y)}) );
 
 	scale();
 }
@@ -1306,7 +1306,7 @@ void FeImage::scale()
 	sf::IntRect texture_rect = m_sprite.getTextureRect();
 	float ratio = m_tex->get_sample_aspect_ratio();
 
-	if (( texture_rect.width == 0 ) || ( texture_rect.height == 0 ))
+	if (( texture_rect.size.x == 0 ) || ( texture_rect.size.y == 0 ))
 		return;
 
 	bool scale=false;
@@ -1315,7 +1315,7 @@ void FeImage::scale()
 
 	if ( m_size.x > 0.0 )
 	{
-		scale_x = (float) m_size.x / abs( texture_rect.width );
+		scale_x = (float) m_size.x / abs( texture_rect.size.x );
 
 		if ( m_preserve_aspect_ratio )
 			scale_y = scale_x;
@@ -1325,7 +1325,7 @@ void FeImage::scale()
 
 	if ( m_size.y > 0.0 )
 	{
-		scale_y = (float) m_size.y / abs( texture_rect.height );
+		scale_y = (float) m_size.y / abs( texture_rect.size.y );
 
 		if ( m_preserve_aspect_ratio )
 		{
@@ -1342,12 +1342,12 @@ void FeImage::scale()
 				t.rotate( m_sprite.getRotation() );
 
 				if ( scale_x > scale_y * ratio ) // centre in x direction
-					final_pos += t.transformPoint(
-						( m_size.x - abs( texture_rect.width ) * scale_y * ratio ) / 2.0,
-						0 );
+					final_pos += t.transformPoint( sf::Vector2f(
+						( m_size.x - abs( texture_rect.size.x ) * scale_y * ratio ) / 2.0,
+						0 ) );
 				else // centre in y direction
-					final_pos += t.transformPoint( 0,
-						( m_size.y - abs( texture_rect.height ) * scale_x / ratio ) / 2.0 );
+					final_pos += t.transformPoint( sf::Vector2f( 0,
+						( m_size.y - abs( texture_rect.size.y ) * scale_x / ratio ) / 2.0 ) );
 			}
 		}
 
@@ -1366,7 +1366,7 @@ void FeImage::scale()
 		m_sprite.setScale( sf::Vector2f( scale_x, scale_y ) );
 
 	m_sprite.setPosition( final_pos );
-	m_sprite.setOrigin( m_origin.x / scale_x, m_origin.y / scale_y );
+	m_sprite.setOrigin( sf::Vector2f( m_origin.x / scale_x, m_origin.y / scale_y ) );
 }
 
 const sf::Vector2f &FeImage::getPosition() const
@@ -1401,14 +1401,14 @@ void FeImage::setPosition( const sf::Vector2f &p )
 
 float FeImage::getRotation() const
 {
-	return m_sprite.getRotation();
+	return m_sprite.getRotation().asDegrees();
 }
 
 void FeImage::setRotation( float r )
 {
-	if ( r != m_sprite.getRotation() )
+	if ( sf::degrees(r) != m_sprite.getRotation() )
 	{
-		m_sprite.setRotation( r );
+		m_sprite.setRotation( sf::degrees(r) );
 		scale();
 		FePresent::script_flag_redraw();
 	}
@@ -1630,22 +1630,22 @@ int FeImage::get_texture_height() const
 
 int FeImage::get_subimg_x() const
 {
-	return getTextureRect().left;
+	return getTextureRect().position.x;
 }
 
 int FeImage::get_subimg_y() const
 {
-	return getTextureRect().top;
+	return getTextureRect().position.y;
 }
 
 int FeImage::get_subimg_width() const
 {
-	return getTextureRect().width;
+	return getTextureRect().size.x;
 }
 
 int FeImage::get_subimg_height() const
 {
-	return getTextureRect().height;
+	return getTextureRect().size.y;
 }
 
 float FeImage::get_sample_aspect_ratio() const
@@ -1661,28 +1661,28 @@ bool FeImage::get_preserve_aspect_ratio() const
 void FeImage::set_subimg_x( int x )
 {
 	sf::IntRect r = getTextureRect();
-	r.left=x;
+	r.position.x=x;
 	setTextureRect( r );
 }
 
 void FeImage::set_subimg_y( int y )
 {
 	sf::IntRect r = getTextureRect();
-	r.top=y;
+	r.position.y=y;
 	setTextureRect( r );
 }
 
 void FeImage::set_subimg_width( int w )
 {
 	sf::IntRect r = getTextureRect();
-	r.width=w;
+	r.size.x=w;
 	setTextureRect( r );
 }
 
 void FeImage::set_subimg_height( int h )
 {
 	sf::IntRect r = getTextureRect();
-	r.height=h;
+	r.size.y=h;
 	setTextureRect( r );
 }
 

--- a/src/fe_input.cpp
+++ b/src/fe_input.cpp
@@ -40,7 +40,7 @@ namespace
 #if ( SFML_VERSION_INT >= FE_VERSION_INT( 2, 2, 0 )) // touch support sfml >= 2.2
 	// globals to track when last touch event "began"
 	//
-	sf::Event g_last_touch;
+	sf::Vector2i g_last_touch_pos;
 	bool g_touch_moved=false;
 #endif
 
@@ -308,179 +308,173 @@ FeInputSingle::FeInputSingle( const sf::Event &e, const sf::IntRect &mc_rect, co
 	: m_type( Unsupported ),
 	m_code( 0 )
 {
-	switch ( e.type )
+	if ( auto* keyPressed = e.getIf<sf::Event::KeyPressed>() )
 	{
-		case sf::Event::KeyPressed:
-			if ( e.key.code != sf::Keyboard::Unknown )
+		if ( keyPressed->code != sf::Keyboard::Key::Unknown )
+		{
+			m_type = Keyboard;
+			m_code = static_cast<int>(keyPressed->code);
+		}
+	}
+	else if ( auto* joyButton = e.getIf<sf::Event::JoystickButtonPressed>() )
+	{
+		m_type = (Type)(Joystick0 + joymap2feid( joyButton->joystickId ));
+		m_code = JoyButton0 + joyButton->button;
+	}
+	else if ( auto* joyMoved = e.getIf<sf::Event::JoystickMoved>() )
+	{
+		if ( std::abs( joyMoved->position ) > joy_thresh )
+		{
+			switch ( joyMoved->axis )
 			{
-				m_type = Keyboard;
-				m_code = e.key.code;
-			}
-			break;
+				case sf::Joystick::Axis::X:
+					m_code = ( joyMoved->position > 0 ) ? JoyRight : JoyLeft;
+					break;
 
-		case sf::Event::JoystickButtonPressed:
-			m_type = (Type)(Joystick0 + joymap2feid( e.joystickButton.joystickId ));
-			m_code = JoyButton0 + e.joystickButton.button;
-			break;
-
-		case sf::Event::JoystickMoved:
-			if ( std::abs( e.joystickMove.position ) > joy_thresh )
-			{
-				switch ( e.joystickMove.axis )
-				{
-					case sf::Joystick::X:
-						m_code = ( e.joystickMove.position > 0 ) ? JoyRight : JoyLeft;
-						break;
-
-					case sf::Joystick::Y:
-						m_code = ( e.joystickMove.position > 0 ) ? JoyDown : JoyUp;
-						break;
+				case sf::Joystick::Axis::Y:
+					m_code = ( joyMoved->position > 0 ) ? JoyDown : JoyUp;
+					break;
 
 #ifdef SFML_SYSTEM_LINUX
-					//
-					// On Linux, SFML's Z and R axes are mapped to Throttle and Rudder controls
-					// They seem to rest at -100 and go up to 100
-					//
-					case sf::Joystick::Z:
-					case sf::Joystick::R:
-						if ( e.joystickMove.position < 0 )
-							return;
+				//
+				// On Linux, SFML's Z and R axes are mapped to Throttle and Rudder controls
+				// They seem to rest at -100 and go up to 100
+				//
+				case sf::Joystick::Axis::Z:
+				case sf::Joystick::Axis::R:
+					if ( joyMoved->position < 0 )
+						return;
 
-						m_code = ( e.joystickMove.axis == sf::Joystick::Z )
-							? JoyZPos : JoyRPos;
-						break;
+					m_code = ( joyMoved->axis == sf::Joystick::Axis::Z )
+						? JoyZPos : JoyRPos;
+					break;
 #else
-					case sf::Joystick::Z:
-						m_code = ( e.joystickMove.position > 0 ) ? JoyZPos : JoyZNeg;
-						break;
+				case sf::Joystick::Axis::Z:
+					m_code = ( joyMoved->position > 0 ) ? JoyZPos : JoyZNeg;
+					break;
 
-					case sf::Joystick::R:
-						m_code = ( e.joystickMove.position > 0 ) ? JoyRPos : JoyRNeg;
-						break;
+				case sf::Joystick::Axis::R:
+					m_code = ( joyMoved->position > 0 ) ? JoyRPos : JoyRNeg;
+					break;
 #endif
 
-					case sf::Joystick::U:
-						m_code = ( e.joystickMove.position > 0 ) ? JoyUPos : JoyUNeg;
-						break;
+				case sf::Joystick::Axis::U:
+					m_code = ( joyMoved->position > 0 ) ? JoyUPos : JoyUNeg;
+					break;
 
-					case sf::Joystick::V:
-						m_code = ( e.joystickMove.position > 0 ) ? JoyVPos : JoyVNeg;
-						break;
+				case sf::Joystick::Axis::V:
+					m_code = ( joyMoved->position > 0 ) ? JoyVPos : JoyVNeg;
+					break;
 
-					case sf::Joystick::PovX:
-						m_code = ( e.joystickMove.position > 0 ) ? JoyPOVXPos : JoyPOVXNeg;
-						break;
+				case sf::Joystick::Axis::PovX:
+					m_code = ( joyMoved->position > 0 ) ? JoyPOVXPos : JoyPOVXNeg;
+					break;
 
-					case sf::Joystick::PovY:
-						m_code = ( e.joystickMove.position > 0 ) ? JoyPOVYPos : JoyPOVYNeg;
-						break;
+				case sf::Joystick::Axis::PovY:
+					m_code = ( joyMoved->position > 0 ) ? JoyPOVYPos : JoyPOVYNeg;
+					break;
 
-					default:
-						ASSERT( 0 ); // unhandled joystick axis encountered
-						return;
-				}
-
-				m_type = (Type)(Joystick0 + joymap2feid( e.joystickMove.joystickId ) );
-			}
-			break;
-
-		case sf::Event::MouseMoved:
-			if ( e.mouseMove.x < mc_rect.left )
-			{
-				m_type = Mouse;
-				m_code = MouseLeft;
-			}
-			else if ( e.mouseMove.y < mc_rect.top )
-			{
-				m_type = Mouse;
-				m_code = MouseUp;
-			}
-			else if ( e.mouseMove.x >= mc_rect.left + mc_rect.width )
-			{
-				m_type = Mouse;
-				m_code = MouseRight;
-			}
-			else if ( e.mouseMove.y >= mc_rect.top + mc_rect.height )
-			{
-				m_type = Mouse;
-				m_code = MouseDown;
-			}
-			break;
-
-		case sf::Event::MouseWheelMoved:
-			m_type = Mouse;
-			if ( e.mouseWheel.delta > 0 )
-				m_code=MouseWheelUp;
-			else
-				m_code=MouseWheelDown;
-			break;
-
-		case sf::Event::MouseButtonPressed:
-			switch ( e.mouseButton.button )
-			{
-				case sf::Mouse::Left: m_code=MouseBLeft; break;
-				case sf::Mouse::Right: m_code=MouseBRight; break;
-				case sf::Mouse::Middle: m_code=MouseBMiddle; break;
-				case sf::Mouse::XButton1: m_code=MouseBX1; break;
-				case sf::Mouse::XButton2: m_code=MouseBX2; break;
 				default:
-					ASSERT( 0 ); // unhandled mouse button encountered
+					ASSERT( 0 ); // unhandled joystick axis encountered
 					return;
 			}
-			m_type = Mouse;
-			break;
 
-#if ( SFML_VERSION_INT >= FE_VERSION_INT( 2, 2, 0 )) // touch support sfml >= 2.2
-		case sf::Event::TouchMoved:
-			{
-				const int THRESH = 100;
-				int diff_x = e.touch.x - g_last_touch.touch.x;
-				int diff_y = e.touch.y - g_last_touch.touch.y;
-
-				if ( abs( diff_y ) > THRESH )
-				{
-					if ( diff_y < 0 )
-						m_code = SwipeUp;
-					else
-						m_code = SwipeDown;
-
-					m_type = Touch;
-
-					g_touch_moved = true;
-					g_last_touch = e;
-				}
-				else if ( abs( diff_x ) > THRESH )
-				{
-					if ( diff_x < 0 )
-						m_code = SwipeRight;
-					else
-						m_code = SwipeLeft;
-
-					m_type = Touch;
-
-					g_touch_moved = true;
-					g_last_touch = e;
-				}
-			}
-			break;
-
-		case sf::Event::TouchBegan:
-			g_touch_moved = false;
-			g_last_touch = e;
-			break;
-
-		case sf::Event::TouchEnded:
-			if ( !g_touch_moved )
-			{
-				m_code = Tap;
-				m_type = Touch;
-			}
-			break;
-#endif
-
-		default:
-			break;
+			m_type = (Type)(Joystick0 + joymap2feid( joyMoved->joystickId ) );
+		}
 	}
+	else if ( auto* mouseMoved = e.getIf<sf::Event::MouseMoved>() )
+	{
+		if ( mouseMoved->position.x < mc_rect.position.x )
+		{
+			m_type = Mouse;
+			m_code = MouseLeft;
+		}
+		else if ( mouseMoved->position.y < mc_rect.position.y )
+		{
+			m_type = Mouse;
+			m_code = MouseUp;
+		}
+		else if ( mouseMoved->position.x >= mc_rect.position.x + mc_rect.size.x )
+		{
+			m_type = Mouse;
+			m_code = MouseRight;
+		}
+		else if ( mouseMoved->position.y >= mc_rect.position.y + mc_rect.size.y )
+		{
+			m_type = Mouse;
+			m_code = MouseDown;
+		}
+	}
+	else if ( auto* mouseWheel = e.getIf<sf::Event::MouseWheelScrolled>() )
+	{
+		m_type = Mouse;
+		if ( mouseWheel->delta > 0 )
+			m_code=MouseWheelUp;
+		else
+			m_code=MouseWheelDown;
+	}
+	else if ( auto* mouseButton = e.getIf<sf::Event::MouseButtonPressed>() )
+	{
+		switch ( mouseButton->button )
+		{
+			case sf::Mouse::Button::Left: m_code=MouseBLeft; break;
+			case sf::Mouse::Button::Right: m_code=MouseBRight; break;
+			case sf::Mouse::Button::Middle: m_code=MouseBMiddle; break;
+			case sf::Mouse::Button::Extra1: m_code=MouseBX1; break;
+			case sf::Mouse::Button::Extra2: m_code=MouseBX2; break;
+			default:
+				ASSERT( 0 ); // unhandled mouse button encountered
+				return;
+		}
+		m_type = Mouse;
+	}
+#if ( SFML_VERSION_INT >= FE_VERSION_INT( 2, 2, 0 ))
+	else if ( auto* touchMoved = e.getIf<sf::Event::TouchMoved>() )
+	{
+		const int THRESH = 100;
+		int diff_x = touchMoved->position.x - g_last_touch_pos.x;
+		int diff_y = touchMoved->position.y - g_last_touch_pos.y;
+
+		if ( abs( diff_y ) > THRESH )
+		{
+			if ( diff_y < 0 )
+				m_code = SwipeUp;
+			else
+				m_code = SwipeDown;
+
+			m_type = Touch;
+
+			g_touch_moved = true;
+			g_last_touch_pos = touchMoved->position;
+		}
+		else if ( abs( diff_x ) > THRESH )
+		{
+			if ( diff_x < 0 )
+				m_code = SwipeRight;
+			else
+				m_code = SwipeLeft;
+
+			m_type = Touch;
+
+			g_touch_moved = true;
+			g_last_touch_pos = touchMoved->position;
+		}
+	}
+	else if ( e.is<sf::Event::TouchBegan>() )
+	{
+		g_touch_moved = false;
+		if ( auto* touchBegan = e.getIf<sf::Event::TouchBegan>() )
+			g_last_touch_pos = touchBegan->position;
+	}
+	else if ( e.is<sf::Event::TouchEnded>() )
+	{
+		if ( !g_touch_moved )
+		{
+			m_code = Tap;
+			m_type = Touch;
+		}
+	}
+#endif
 }
 
 FeInputSingle::FeInputSingle( const std::string &str )
@@ -628,11 +622,11 @@ bool FeInputSingle::get_current_state( int joy_thresh ) const
 	{
 		switch ( m_code )
 		{
-		case MouseBLeft: return sf::Mouse::isButtonPressed( sf::Mouse::Left );
-		case MouseBRight: return sf::Mouse::isButtonPressed( sf::Mouse::Right );
-		case MouseBMiddle: return sf::Mouse::isButtonPressed( sf::Mouse::Middle );
-		case MouseBX1: return sf::Mouse::isButtonPressed( sf::Mouse::XButton1 );
-		case MouseBX2: return sf::Mouse::isButtonPressed( sf::Mouse::XButton2 );
+		case MouseBLeft: return sf::Mouse::isButtonPressed( sf::Mouse::Button::Left );
+		case MouseBRight: return sf::Mouse::isButtonPressed( sf::Mouse::Button::Right );
+		case MouseBMiddle: return sf::Mouse::isButtonPressed( sf::Mouse::Button::Middle );
+		case MouseBX1: return sf::Mouse::isButtonPressed( sf::Mouse::Button::Extra1 );
+		case MouseBX2: return sf::Mouse::isButtonPressed( sf::Mouse::Button::Extra2 );
 		default: return false; // mouse moves and wheels are not supported
 		}
 	}
@@ -650,22 +644,22 @@ bool FeInputSingle::get_current_state( int joy_thresh ) const
 		{
 			switch ( m_code )
 			{
-				case JoyLeft: return ( -sf::Joystick::getAxisPosition( id, sf::Joystick::X ) > joy_thresh );
-				case JoyRight: return ( sf::Joystick::getAxisPosition( id, sf::Joystick::X ) > joy_thresh );
-				case JoyUp: return ( -sf::Joystick::getAxisPosition( id, sf::Joystick::Y ) > joy_thresh );
-				case JoyDown: return ( sf::Joystick::getAxisPosition( id, sf::Joystick::Y ) > joy_thresh );
-				case JoyZPos: return ( sf::Joystick::getAxisPosition( id, sf::Joystick::Z ) > joy_thresh );
-				case JoyZNeg: return ( -sf::Joystick::getAxisPosition( id, sf::Joystick::Z ) > joy_thresh );
-				case JoyRPos: return ( sf::Joystick::getAxisPosition( id, sf::Joystick::R ) > joy_thresh );
-				case JoyRNeg: return ( -sf::Joystick::getAxisPosition( id, sf::Joystick::R ) > joy_thresh );
-				case JoyUPos: return ( sf::Joystick::getAxisPosition( id, sf::Joystick::U ) > joy_thresh );
-				case JoyUNeg: return ( -sf::Joystick::getAxisPosition( id, sf::Joystick::U ) > joy_thresh );
-				case JoyVPos: return ( sf::Joystick::getAxisPosition( id, sf::Joystick::V ) > joy_thresh );
-				case JoyVNeg: return ( -sf::Joystick::getAxisPosition( id, sf::Joystick::V ) > joy_thresh );
-				case JoyPOVXPos: return ( sf::Joystick::getAxisPosition( id, sf::Joystick::PovX ) > joy_thresh );
-				case JoyPOVXNeg: return ( -sf::Joystick::getAxisPosition( id, sf::Joystick::PovX ) > joy_thresh );
-				case JoyPOVYPos: return ( sf::Joystick::getAxisPosition( id, sf::Joystick::PovY ) > joy_thresh );
-				case JoyPOVYNeg: return ( -sf::Joystick::getAxisPosition( id, sf::Joystick::PovY ) > joy_thresh );
+				case JoyLeft: return ( -sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::X ) > joy_thresh );
+				case JoyRight: return ( sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::X ) > joy_thresh );
+				case JoyUp: return ( -sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::Y ) > joy_thresh );
+				case JoyDown: return ( sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::Y ) > joy_thresh );
+				case JoyZPos: return ( sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::Z ) > joy_thresh );
+				case JoyZNeg: return ( -sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::Z ) > joy_thresh );
+				case JoyRPos: return ( sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::R ) > joy_thresh );
+				case JoyRNeg: return ( -sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::R ) > joy_thresh );
+				case JoyUPos: return ( sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::U ) > joy_thresh );
+				case JoyUNeg: return ( -sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::U ) > joy_thresh );
+				case JoyVPos: return ( sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::V ) > joy_thresh );
+				case JoyVNeg: return ( -sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::V ) > joy_thresh );
+				case JoyPOVXPos: return ( sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::PovX ) > joy_thresh );
+				case JoyPOVXNeg: return ( -sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::PovX ) > joy_thresh );
+				case JoyPOVYPos: return ( sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::PovY ) > joy_thresh );
+				case JoyPOVYNeg: return ( -sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::PovY ) > joy_thresh );
 				default: return false;
 			}
 		}
@@ -693,22 +687,22 @@ int FeInputSingle::get_current_pos() const
 
 		switch ( m_code )
 		{
-			case JoyLeft: temp = -sf::Joystick::getAxisPosition( id, sf::Joystick::X ); break;
-			case JoyRight: temp = sf::Joystick::getAxisPosition( id, sf::Joystick::X ); break;
-			case JoyUp: temp = -sf::Joystick::getAxisPosition( id, sf::Joystick::Y ); break;
-			case JoyDown: temp = sf::Joystick::getAxisPosition( id, sf::Joystick::Y ); break;
-			case JoyZPos: temp = sf::Joystick::getAxisPosition( id, sf::Joystick::Z ); break;
-			case JoyZNeg: temp = -sf::Joystick::getAxisPosition( id, sf::Joystick::Z ); break;
-			case JoyRPos: temp = sf::Joystick::getAxisPosition( id, sf::Joystick::R ); break;
-			case JoyRNeg: temp = -sf::Joystick::getAxisPosition( id, sf::Joystick::R ); break;
-			case JoyUPos: temp = sf::Joystick::getAxisPosition( id, sf::Joystick::U ); break;
-			case JoyUNeg: temp = -sf::Joystick::getAxisPosition( id, sf::Joystick::U ); break;
-			case JoyVPos: temp = sf::Joystick::getAxisPosition( id, sf::Joystick::V ); break;
-			case JoyVNeg: temp = -sf::Joystick::getAxisPosition( id, sf::Joystick::V ); break;
-			case JoyPOVXPos: temp = sf::Joystick::getAxisPosition( id, sf::Joystick::PovX ); break;
-			case JoyPOVXNeg: temp = -sf::Joystick::getAxisPosition( id, sf::Joystick::PovX ); break;
-			case JoyPOVYPos: temp = sf::Joystick::getAxisPosition( id, sf::Joystick::PovY ); break;
-			case JoyPOVYNeg: temp = -sf::Joystick::getAxisPosition( id, sf::Joystick::PovY ); break;
+			case JoyLeft: temp = -sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::X ); break;
+			case JoyRight: temp = sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::X ); break;
+			case JoyUp: temp = -sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::Y ); break;
+			case JoyDown: temp = sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::Y ); break;
+			case JoyZPos: temp = sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::Z ); break;
+			case JoyZNeg: temp = -sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::Z ); break;
+			case JoyRPos: temp = sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::R ); break;
+			case JoyRNeg: temp = -sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::R ); break;
+			case JoyUPos: temp = sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::U ); break;
+			case JoyUNeg: temp = -sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::U ); break;
+			case JoyVPos: temp = sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::V ); break;
+			case JoyVNeg: temp = -sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::V ); break;
+			case JoyPOVXPos: temp = sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::PovX ); break;
+			case JoyPOVXNeg: temp = -sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::PovX ); break;
+			case JoyPOVYPos: temp = sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::PovY ); break;
+			case JoyPOVYNeg: temp = -sf::Joystick::getAxisPosition( id, sf::Joystick::Axis::PovY ); break;
 			default: break;
 		}
 
@@ -1013,18 +1007,18 @@ void FeInputMap::initialize_mappings()
 		struct DefaultMappings { FeInputSingle::Type type; int code; Command comm; };
 		DefaultMappings dmap[] =
 		{
-			{ FeInputSingle::Keyboard,    sf::Keyboard::Escape,        Back },
+			{ FeInputSingle::Keyboard,    static_cast<int>(sf::Keyboard::Key::Escape),        Back },
 			{ FeInputSingle::Joystick0,   FeInputSingle::JoyButton0+1, Back },
-			{ FeInputSingle::Keyboard,    sf::Keyboard::Up,            Up },
+			{ FeInputSingle::Keyboard,    static_cast<int>(sf::Keyboard::Key::Up),            Up },
 			{ FeInputSingle::Joystick0,   FeInputSingle::JoyUp,        Up },
-			{ FeInputSingle::Keyboard,    sf::Keyboard::Down,          Down },
+			{ FeInputSingle::Keyboard,    static_cast<int>(sf::Keyboard::Key::Down),          Down },
 			{ FeInputSingle::Joystick0,   FeInputSingle::JoyDown,      Down },
-			{ FeInputSingle::Keyboard,    sf::Keyboard::Left,          Left },
+			{ FeInputSingle::Keyboard,    static_cast<int>(sf::Keyboard::Key::Left),          Left },
 			{ FeInputSingle::Joystick0,   FeInputSingle::JoyLeft,      Left },
-			{ FeInputSingle::Keyboard,    sf::Keyboard::Right,         Right },
+			{ FeInputSingle::Keyboard,    static_cast<int>(sf::Keyboard::Key::Right),         Right },
 			{ FeInputSingle::Joystick0,   FeInputSingle::JoyRight,     Right },
-			{ FeInputSingle::Keyboard,    sf::Keyboard::Return,        Select },
-			{ FeInputSingle::Keyboard,    sf::Keyboard::LControl,      Select },
+			{ FeInputSingle::Keyboard,    static_cast<int>(sf::Keyboard::Key::Enter),        Select },
+			{ FeInputSingle::Keyboard,    static_cast<int>(sf::Keyboard::Key::LControl),      Select },
 			{ FeInputSingle::Joystick0,   FeInputSingle::JoyButton0,   Select },
 
 #ifdef SFML_SYSTEM_ANDROID
@@ -1035,7 +1029,7 @@ void FeInputMap::initialize_mappings()
 			{ FeInputSingle::Touch,       FeInputSingle::Tap,          Select },
 #endif
 
-			{ FeInputSingle::Unsupported, sf::Keyboard::Unknown,     LAST_COMMAND }	// keep as last
+			{ FeInputSingle::Unsupported, static_cast<int>(sf::Keyboard::Key::Unknown),     LAST_COMMAND }	// keep as last
 		};
 
 		int i=0;
@@ -1135,44 +1129,64 @@ FeInputMap::Command FeInputMap::map_input( const sf::Event &e, const sf::IntRect
 {
 	FeInputSingle index( e, mc_rect, joy_thresh );
 
-	switch ( e.type )
+	if ( e.is<sf::Event::Closed>() )
 	{
-	case sf::Event::Closed:
 		m_tracked_keys.clear();
 		return ExitToDesktop;
+	}
 
-	case sf::Event::JoystickMoved:
+	if ( auto* joyMoved = e.getIf<sf::Event::JoystickMoved>() )
+	{
+		//
+		// Test that this is a release of a tracked key (joystick axis)
+		//
+		if (( !index.get_current_state( joy_thresh ) )
+			&& ( m_tracked_keys.find( index ) != m_tracked_keys.end() ))
 		{
-			//
-			// Test that this is a release of a tracked key (joystick axis)
-			//
-			if (( !index.get_current_state( joy_thresh ) )
-				&& ( m_tracked_keys.find( index ) != m_tracked_keys.end() ))
-			{
-				FeInputMap::Command temp = get_command_from_tracked_keys( joy_thresh );
-				if ( temp != LAST_COMMAND )
-					return temp;
-			}
+			FeInputMap::Command temp = get_command_from_tracked_keys( joy_thresh );
+			if ( temp != LAST_COMMAND )
+				return temp;
 		}
-		break;
+	}
 
-	case sf::Event::KeyReleased:
-	case sf::Event::JoystickButtonReleased:
-	case sf::Event::MouseButtonReleased:
+	if ( auto* keyReleased = e.getIf<sf::Event::KeyReleased>() )
+	{
+		//
+		// Test that this is a release of a tracked key (button)
+		//
+		FeInputSingle tt( FeInputSingle::Keyboard, static_cast<int>(keyReleased->code) );
+		if ( m_tracked_keys.find( tt ) != m_tracked_keys.end() )
 		{
-			//
-			// Test that this is a release of a tracked key (button)
-			//
-			sf::Event te = e;
-			switch ( e.type )
-			{
-			case sf::Event::KeyReleased: te.type = sf::Event::KeyPressed; break;
-			case sf::Event::JoystickButtonReleased: te.type = sf::Event::JoystickButtonPressed; break;
-			case sf::Event::MouseButtonReleased: te.type = sf::Event::MouseButtonPressed; break;
-			default: ASSERT( 0 ); break;
-			}
-
-			FeInputSingle tt( te, mc_rect, joy_thresh );
+			FeInputMap::Command temp = get_command_from_tracked_keys( joy_thresh );
+			if ( temp != LAST_COMMAND )
+				return temp;
+		}
+	}
+	else if ( auto* joyButtonReleased = e.getIf<sf::Event::JoystickButtonReleased>() )
+	{
+		FeInputSingle tt( (FeInputSingle::Type)(FeInputSingle::Joystick0 + joymap2feid(joyButtonReleased->joystickId)), FeInputSingle::JoyButton0 + joyButtonReleased->button );
+		if ( m_tracked_keys.find( tt ) != m_tracked_keys.end() )
+		{
+			FeInputMap::Command temp = get_command_from_tracked_keys( joy_thresh );
+			if ( temp != LAST_COMMAND )
+				return temp;
+		}
+	}
+	else if ( auto* mouseButtonReleased = e.getIf<sf::Event::MouseButtonReleased>() )
+	{
+		int mouseCode = 0;
+		switch ( mouseButtonReleased->button )
+		{
+			case sf::Mouse::Button::Left: mouseCode = FeInputSingle::MouseBLeft; break;
+			case sf::Mouse::Button::Right: mouseCode = FeInputSingle::MouseBRight; break;
+			case sf::Mouse::Button::Middle: mouseCode = FeInputSingle::MouseBMiddle; break;
+			case sf::Mouse::Button::Extra1: mouseCode = FeInputSingle::MouseBX1; break;
+			case sf::Mouse::Button::Extra2: mouseCode = FeInputSingle::MouseBX2; break;
+			default: mouseCode = -1; break;
+		}
+		if ( mouseCode >= 0 )
+		{
+			FeInputSingle tt( FeInputSingle::Mouse, mouseCode );
 			if ( m_tracked_keys.find( tt ) != m_tracked_keys.end() )
 			{
 				FeInputMap::Command temp = get_command_from_tracked_keys( joy_thresh );
@@ -1180,25 +1194,21 @@ FeInputMap::Command FeInputMap::map_input( const sf::Event &e, const sf::IntRect
 					return temp;
 			}
 		}
-		break;
+	}
 
-	case sf::Event::MouseMoved:
-#if ( SFML_VERSION_INT >= FE_VERSION_INT( 2, 2, 0 )) // touch support sfml >= 2.2
-	case sf::Event::TouchEnded:
+	if ( e.is<sf::Event::MouseMoved>()
+#if ( SFML_VERSION_INT >= FE_VERSION_INT( 2, 2, 0 ))
+		|| e.is<sf::Event::TouchEnded>()
 #endif
-		{
-			m_tracked_keys.insert( index );
-			FeInputMap::Command temp = get_command_from_tracked_keys( joy_thresh );
-			if ( temp != LAST_COMMAND )
-				return temp;
+		)
+	{
+		m_tracked_keys.insert( index );
+		FeInputMap::Command temp = get_command_from_tracked_keys( joy_thresh );
+		if ( temp != LAST_COMMAND )
+			return temp;
 
-			m_tracked_keys.erase( index );
-			return LAST_COMMAND;
-		}
-		break;
-
-	default:
-		break;
+		m_tracked_keys.erase( index );
+		return LAST_COMMAND;
 	}
 
 	if ( index.get_type() == FeInputSingle::Unsupported )

--- a/src/fe_listbox.cpp
+++ b/src/fe_listbox.cpp
@@ -135,7 +135,7 @@ void FeListBox::init_dimensions()
 		m_texts.reserve( m_rows );
 
 	sf::Transform rotater;
-	rotater.rotate( m_rotation, pos.x, pos.y );
+	rotater.rotate( sf::degrees( m_rotation ), pos );
 
 	for ( int i=0; i< m_rows; i++ )
 	{
@@ -147,7 +147,7 @@ void FeListBox::init_dimensions()
 			t.setStyle( m_selStyle );
 		}
 
-		t.setPosition( rotater.transformPoint( pos.x, pos.y+(i*actual_spacing)) );
+		t.setPosition( rotater.transformPoint( sf::Vector2f( pos.x, pos.y+(i*actual_spacing) ) ) );
 		t.setSize( size.x, actual_spacing );
 		t.setRotation( m_rotation );
 

--- a/src/fe_overlay.cpp
+++ b/src/fe_overlay.cpp
@@ -29,6 +29,8 @@
 #include <SFML/Graphics.hpp>
 #include <iostream>
 #include <cmath>
+#include <cstdint>
+#include <optional>
 
 #ifndef M_PI
    #define M_PI 3.14159265358979323846
@@ -154,7 +156,7 @@ public:
 	int max_sel;		// [in] maximum selection
 
 	int move_count;
-	sf::Event move_event;
+	std::optional<sf::Event> move_event;
 	sf::Clock move_timer;
 	FeInputMap::Command move_command;
 	FeInputMap::Command extra_exit;
@@ -776,7 +778,7 @@ bool FeOverlay::edit_dialog(
 	draw_list.push_back( &message );
 	draw_list.push_back( &tp );
 
-	std::basic_string<sf::Uint32> str;
+	std::basic_string<std::uint32_t> str;
 	sf::Utf8::toUtf32( text.begin(), text.end(), std::back_inserter( str ) );
 
 	FeFlagMinder fm( m_overlay_is_on );
@@ -822,8 +824,7 @@ void FeOverlay::input_map_dialog(
 	sf::Mouse::setPosition( sf::Vector2i( win_size.x/2, win_size.y/2 ), m_wnd.get_win() );
 
 	// empty the window event queue
-	sf::Event ev;
-	while ( m_wnd.pollEvent(ev) )
+	while ( m_wnd.pollEvent() )
 	{
 		// no op
 	}
@@ -847,28 +848,30 @@ void FeOverlay::input_map_dialog(
 	const sf::Transform &t = m_fePresent.get_transform();
 	while ( m_wnd.isOpen() )
 	{
-		while (m_wnd.pollEvent(ev))
+		while ( auto ev = m_wnd.pollEvent() )
 		{
-			if ( ev.type == sf::Event::Closed )
+			if ( ev->is<sf::Event::Closed>() )
 				return;
 
-			if ( multi_mode && ((ev.type == sf::Event::KeyReleased )
-					|| ( ev.type == sf::Event::JoystickButtonReleased )
-					|| ( ev.type == sf::Event::MouseButtonReleased )))
+			if ( multi_mode && ((ev->is<sf::Event::KeyReleased>() )
+					|| ( ev->is<sf::Event::JoystickButtonReleased>() )
+					|| ( ev->is<sf::Event::MouseButtonReleased>() )))
 				done = true;
 			else
 			{
-				FeInputSingle single( ev, mc_rect, joy_thresh );
+				FeInputSingle single( *ev, mc_rect, joy_thresh );
 				if ( single.get_type() != FeInputSingle::Unsupported )
 				{
-					if (( ev.type == sf::Event::KeyPressed )
-							|| ( ev.type == sf::Event::JoystickButtonPressed )
-							|| ( ev.type == sf::Event::MouseButtonPressed ))
+					if (( ev->is<sf::Event::KeyPressed>() )
+							|| ( ev->is<sf::Event::JoystickButtonPressed>() )
+							|| ( ev->is<sf::Event::MouseButtonPressed>() ))
 						multi_mode = true;
-					else if ( ev.type == sf::Event::JoystickMoved )
+					else if ( ev->is<sf::Event::JoystickMoved>() )
 					{
 						multi_mode = true;
-						joystick_moves.insert( std::pair<int,int>( ev.joystickMove.joystickId, ev.joystickMove.axis ) );
+						auto* joyMoved = ev->getIf<sf::Event::JoystickMoved>();
+						if (joyMoved)
+							joystick_moves.insert( std::pair<int,int>( static_cast<int>(joyMoved->joystickId), static_cast<int>(joyMoved->axis) ) );
 					}
 
 					bool dup=false;
@@ -892,13 +895,15 @@ void FeOverlay::input_map_dialog(
 					if ( !multi_mode )
 						done = true;
 				}
-				else if ( ev.type == sf::Event::JoystickMoved )
+				else if ( ev->is<sf::Event::JoystickMoved>() )
 				{
-					// test if a joystick has been released
-					std::pair<int,int> test( ev.joystickMove.joystickId, ev.joystickMove.axis );
-
-					if ( joystick_moves.find( test ) != joystick_moves.end() )
-						done = true;
+					auto* joyMoved = ev->getIf<sf::Event::JoystickMoved>();
+					if (joyMoved)
+					{
+						std::pair<int,int> test( joyMoved->joystickId, static_cast<int>(joyMoved->axis) );
+						if ( joystick_moves.find( test ) != joystick_moves.end() )
+							done = true;
+					}
 				}
 			}
 		}
@@ -1290,7 +1295,7 @@ int FeOverlay::display_config_dialog(
 			else
 			{
 				const std::string &e_str( ctx.curr_opt().get_value() );
-				std::basic_string<sf::Uint32> str;
+				std::basic_string<std::uint32_t> str;
 				sf::Utf8::toUtf32( e_str.begin(), e_str.end(),
 						std::back_inserter( str ) );
 
@@ -1318,10 +1323,9 @@ int FeOverlay::display_config_dialog(
 
 bool FeOverlay::check_for_cancel()
 {
-	sf::Event ev;
-	while (m_wnd.pollEvent(ev))
+	while (const std::optional event = m_wnd.pollEvent())
 	{
-		FeInputMap::Command c = m_feSettings.map_input( ev );
+		FeInputMap::Command c = m_feSettings.map_input( *event );
 
 		if (( c == FeInputMap::Back )
 				|| ( c == FeInputMap::Exit )
@@ -1346,8 +1350,7 @@ void FeOverlay::init_event_loop( FeEventLoopCtx &ctx )
 				|| m_feSettings.get_current_state( FeInputMap::ExitToDesktop )
 				|| m_feSettings.get_current_state( FeInputMap::Select ) ))
 	{
-		sf::Event ev;
-		while (m_wnd.pollEvent(ev))
+		while (m_wnd.pollEvent())
 		{
 		}
 
@@ -1381,22 +1384,25 @@ bool FeOverlay::event_loop( FeEventLoopCtx &ctx )
 
 	while ( m_wnd.isOpen() )
 	{
-		sf::Event ev;
-		while (m_wnd.pollEvent(ev))
+		while (const std::optional event = m_wnd.pollEvent())
 		{
-			FeInputMap::Command c = m_feSettings.map_input( ev );
+			FeInputMap::Command c = m_feSettings.map_input( *event );
 
 			if (( c != FeInputMap::LAST_COMMAND )
 					&& ( c == ctx.extra_exit ))
 				c = FeInputMap::Exit;
 
-			if ( ( ev.type == sf::Event::MouseMoved )
-				&& ((ev.mouseMove.x != last_mouse_pos.x) || (ev.mouseMove.y != last_mouse_pos.y))
-				&& ( m_feSettings.test_mouse_reset( ev.mouseMove.x, ev.mouseMove.y ) ) )
+			if ( const auto* mouseMoved = event->getIf<sf::Event::MouseMoved>() )
 			{
-				last_mouse_pos = sf::Vector2i( ev.mouseMove.x, ev.mouseMove.y );
-				sf::Vector2u s = m_wnd.get_win().getSize();
-				sf::Mouse::setPosition( sf::Vector2i( s.x / 2, s.y / 2 ), m_wnd.get_win() );
+				if ((mouseMoved->position.x != last_mouse_pos.x) || (mouseMoved->position.y != last_mouse_pos.y))
+				{
+					if ( m_feSettings.test_mouse_reset( mouseMoved->position.x, mouseMoved->position.y ) )
+					{
+						last_mouse_pos = sf::Vector2i( mouseMoved->position.x, mouseMoved->position.y );
+						sf::Vector2u s = m_wnd.get_win().getSize();
+						sf::Mouse::setPosition( sf::Vector2i( s.x / 2, s.y / 2 ), m_wnd.get_win() );
+					}
+				}
 			}
 
 			switch( c )
@@ -1410,36 +1416,36 @@ bool FeOverlay::event_loop( FeEventLoopCtx &ctx )
 			case FeInputMap::Select:
 				return true;
 			case FeInputMap::Up:
-				if (( ev.type == sf::Event::JoystickMoved )
-						&& ( ctx.move_event.type == sf::Event::JoystickMoved ))
+				if ( event->is<sf::Event::JoystickMoved>()
+						&& ctx.move_event && ctx.move_event->is<sf::Event::JoystickMoved>() )
 					return false;
 
 				if ( ctx.sel > 0 )
 					ctx.sel--;
-				else if ( ev.type != sf::Event::MouseMoved )
+				else if ( !event->is<sf::Event::MouseMoved>() )
 					ctx.sel = ctx.max_sel;
 				else
 					ctx.sel = 0;
 
-				ctx.move_event = ev;
+				ctx.move_event = *event;
 				ctx.move_command = FeInputMap::Up;
 				ctx.move_count = 0;
 				ctx.move_timer.restart();
 				return false;
 
 			case FeInputMap::Down:
-				if (( ev.type == sf::Event::JoystickMoved )
-						&& ( ctx.move_event.type == sf::Event::JoystickMoved ))
+				if ( event->is<sf::Event::JoystickMoved>()
+						&& ctx.move_event && ctx.move_event->is<sf::Event::JoystickMoved>() )
 					return false;
 
 				if ( ctx.sel < ctx.max_sel )
 					ctx.sel++;
-				else if ( ev.type != sf::Event::MouseMoved )
+				else if ( !event->is<sf::Event::MouseMoved>() )
 					ctx.sel = 0;
 				else
 					ctx.sel = ctx.max_sel;
 
-				ctx.move_event = ev;
+				ctx.move_event = *event;
 				ctx.move_command = FeInputMap::Down;
 				ctx.move_count = 0;
 				ctx.move_timer.restart();
@@ -1473,39 +1479,31 @@ bool FeOverlay::event_loop( FeEventLoopCtx &ctx )
 		{
 			bool cont=false;
 
-			switch ( ctx.move_event.type )
+			if ( ctx.move_event )
 			{
-			case sf::Event::KeyPressed:
-				if ( sf::Keyboard::isKeyPressed( ctx.move_event.key.code ) )
-					cont=true;
-				break;
-
-			case sf::Event::MouseButtonPressed:
-				if ( sf::Mouse::isButtonPressed( ctx.move_event.mouseButton.button ) )
-					cont=true;
-				break;
-
-			case sf::Event::JoystickButtonPressed:
-				if ( sf::Joystick::isButtonPressed(
-						ctx.move_event.joystickButton.joystickId,
-						ctx.move_event.joystickButton.button ) )
-					cont=true;
-				break;
-
-			case sf::Event::JoystickMoved:
+				if ( const auto* keyPressed = ctx.move_event->getIf<sf::Event::KeyPressed>() )
+				{
+					if ( sf::Keyboard::isKeyPressed( keyPressed->code ) )
+						cont=true;
+				}
+				else if ( const auto* mouseButton = ctx.move_event->getIf<sf::Event::MouseButtonPressed>() )
+				{
+					if ( sf::Mouse::isButtonPressed( mouseButton->button ) )
+						cont=true;
+				}
+				else if ( const auto* joyButton = ctx.move_event->getIf<sf::Event::JoystickButtonPressed>() )
+				{
+					if ( sf::Joystick::isButtonPressed( joyButton->joystickId, joyButton->button ) )
+						cont=true;
+				}
+				else if ( const auto* joyMoved = ctx.move_event->getIf<sf::Event::JoystickMoved>() )
 				{
 					sf::Joystick::update();
 
-					float pos = sf::Joystick::getAxisPosition(
-							ctx.move_event.joystickMove.joystickId,
-							ctx.move_event.joystickMove.axis );
+					float pos = sf::Joystick::getAxisPosition( joyMoved->joystickId, joyMoved->axis );
 					if ( std::abs( pos ) > m_feSettings.get_joy_thresh() )
 						cont=true;
 				}
-				break;
-
-			default:
-				break;
 			}
 
 			if ( cont )
@@ -1532,7 +1530,7 @@ bool FeOverlay::event_loop( FeEventLoopCtx &ctx )
 			else
 			{
 				ctx.move_command = FeInputMap::LAST_COMMAND;
-				ctx.move_event = sf::Event();
+				ctx.move_event.reset();
 			}
 		}
 	}
@@ -1665,47 +1663,42 @@ int get_char_idx( unsigned char c )
 };
 
 bool FeOverlay::edit_loop( std::vector<sf::Drawable *> d,
-			std::basic_string<sf::Uint32> &str, FeTextPrimative *tp )
+			std::basic_string<std::uint32_t> &str, FeTextPrimative *tp )
 {
 	sf::Clock cursor_timer;
 	const sf::Transform &t = m_fePresent.get_transform();
 
 	const sf::Font *font = tp->getFont();
-	sf::Text cursor( "|", *font, tp->getCharacterSize() / tp->getTextScale().x );
-#if ( SFML_VERSION_INT >= FE_VERSION_INT( 2, 4, 0 ) )
+	sf::Text cursor( *font, "|", tp->getCharacterSize() / tp->getTextScale().x );
 	cursor.setFillColor( tp->getColor() );
-#else
-	cursor.setColor( tp->getColor() );
-#endif
 	cursor.setStyle( sf::Text::Bold );
 	cursor.setScale( tp->getTextScale() );
 
 	int cursor_pos=str.size();
+	sf::FloatRect bounds = cursor.getLocalBounds();
 	cursor.setPosition( tp->setString( str, cursor_pos ) - sf::Vector2f((
-		cursor.getLocalBounds().width + cursor.getLocalBounds().left - 2.0 ) * cursor.getScale().x,
-		cursor.getLocalBounds().top * cursor.getScale().y / 2.0 ));
+		bounds.size.x + bounds.position.x - 2.0 ) * cursor.getScale().x,
+		bounds.position.y * cursor.getScale().y / 2.0 ));
 
 	bool redraw=true;
 	FeKeyRepeat key_repeat_enabler( m_wnd.get_win() );
 
-	sf::Event joy_guard;
+	std::optional<sf::Event> joy_guard;
 	bool did_delete( false ); // flag if the user just deleted a character using the UI controls
 
 	while ( m_wnd.isOpen() )
 	{
-		sf::Event ev;
-		while (m_wnd.pollEvent(ev))
+		while (const std::optional event = m_wnd.pollEvent())
 		{
-			switch ( ev.type )
+			if ( event->is<sf::Event::Closed>() )
 			{
-			case sf::Event::Closed:
 				return false;
-
-			case sf::Event::TextEntered:
-
+			}
+			else if ( const auto* textEntered = event->getIf<sf::Event::TextEntered>() )
+			{
 				did_delete = false;
 
-				if ( ev.text.unicode == 8 ) // backspace
+				if ( textEntered->unicode == 8 ) // backspace
 				{
 					if ( cursor_pos > 0 )
 					{
@@ -1713,76 +1706,69 @@ bool FeOverlay::edit_loop( std::vector<sf::Drawable *> d,
 						cursor_pos--;
 					}
 					redraw = true;
-					break;
 				}
+				else if (( textEntered->unicode >= 32 ) && ( textEntered->unicode != 127 ))
+				{
+					if ( cursor_pos < (int)str.size() )
+						str.insert( cursor_pos, 1, textEntered->unicode );
+					else
+						str += textEntered->unicode;
 
-				//
-				// Don't respond to control characters < 32 (line feeds etc.)
-				// and don't handle 127 (delete) here, it is dealt with as a keypress
-				//
-				if (( ev.text.unicode < 32 ) || ( ev.text.unicode == 127 ))
-					break;
-
-				if ( cursor_pos < (int)str.size() )
-					str.insert( cursor_pos, 1, ev.text.unicode );
-				else
-					str += ev.text.unicode;
-
-				cursor_pos++;
-				redraw = true;
-				break;
-
-			case sf::Event::KeyPressed:
-
+					cursor_pos++;
+					redraw = true;
+				}
+			}
+			else if ( const auto* keyPressed = event->getIf<sf::Event::KeyPressed>() )
+			{
 				did_delete = false;
 
-				switch ( ev.key.code )
+				switch ( keyPressed->code )
 				{
-				case sf::Keyboard::Left:
+				case sf::Keyboard::Key::Left:
 					if ( cursor_pos > 0 )
 						cursor_pos--;
 
 					redraw = true;
 					break;
 
-				case sf::Keyboard::Right:
+				case sf::Keyboard::Key::Right:
 					if ( cursor_pos < (int)str.size() )
 						cursor_pos++;
 
 					redraw = true;
 					break;
 
-				case sf::Keyboard::Return:
+				case sf::Keyboard::Key::Enter:
 					return true;
 
-				case sf::Keyboard::Escape:
+				case sf::Keyboard::Key::Escape:
 					return false;
 
-				case sf::Keyboard::End:
+				case sf::Keyboard::Key::End:
 					cursor_pos = str.size();
 					redraw = true;
 					break;
 
-				case sf::Keyboard::Home:
+				case sf::Keyboard::Key::Home:
 					cursor_pos = 0;
 					redraw = true;
 					break;
 
-				case sf::Keyboard::Delete:
+				case sf::Keyboard::Key::Delete:
 					if ( cursor_pos < (int)str.size() )
 						str.erase( cursor_pos, 1 );
 
 					redraw = true;
 					break;
 
-				case sf::Keyboard::V:
+				case sf::Keyboard::Key::V:
 #ifdef SFML_SYSTEM_MACOS
-					if ( ev.key.system )
+					if ( keyPressed->scancode == sf::Keyboard::Scancode::V )
 #else
-					if ( ev.key.control )
+					if ( keyPressed->scancode == sf::Keyboard::Scancode::V )
 #endif
 					{
-						std::basic_string<sf::Uint32> temp = clipboard_get_content();
+						std::basic_string<std::uint32_t> temp = clipboard_get_content();
 						str.insert( cursor_pos, temp.c_str() );
 						cursor_pos += temp.length();
 					}
@@ -1792,133 +1778,131 @@ bool FeOverlay::edit_loop( std::vector<sf::Drawable *> d,
 				default:
 					break;
 				}
-				break;
-
-			default:
+			}
+			else
+			{
 				//
 				// Handle UI actions from non-keyboard input
 				//
+				FeInputMap::Command c = m_feSettings.map_input( *event );
+
+				switch ( c )
 				{
-					FeInputMap::Command c = m_feSettings.map_input( ev );
+				case FeInputMap::Left:
+					if ( event->is<sf::Event::JoystickMoved>()
+							&& joy_guard && joy_guard->is<sf::Event::JoystickMoved>() )
+						break;
 
-					switch ( c )
+					did_delete = false;
+
+					if ( cursor_pos > 0 )
+						cursor_pos--;
+
+					redraw = true;
+
+					if ( event->is<sf::Event::JoystickMoved>() )
+						joy_guard = *event;
+					break;
+
+				case FeInputMap::Right:
+					if ( event->is<sf::Event::JoystickMoved>()
+							&& joy_guard && joy_guard->is<sf::Event::JoystickMoved>() )
+						break;
+
+					did_delete = false;
+
+					if ( cursor_pos < (int)str.size() )
+						cursor_pos++;
+
+					redraw = true;
+
+					if ( event->is<sf::Event::JoystickMoved>() )
+						joy_guard = *event;
+					break;
+
+				case FeInputMap::Up:
+					if ( event->is<sf::Event::JoystickMoved>()
+							&& joy_guard && joy_guard->is<sf::Event::JoystickMoved>() )
+						break;
+
+					if ( cursor_pos < (int)str.size() )
 					{
-					case FeInputMap::Left:
-						if (( ev.type == sf::Event::JoystickMoved )
-								&& ( joy_guard.type == sf::Event::JoystickMoved ))
-							break;
-
-						did_delete = false;
-
-						if ( cursor_pos > 0 )
-							cursor_pos--;
-
-						redraw = true;
-
-						if ( ev.type == sf::Event::JoystickMoved )
-							joy_guard = ev;
-						break;
-
-					case FeInputMap::Right:
-						if (( ev.type == sf::Event::JoystickMoved )
-								&& ( joy_guard.type == sf::Event::JoystickMoved ))
-							break;
-
-						did_delete = false;
-
-						if ( cursor_pos < (int)str.size() )
-							cursor_pos++;
-
-						redraw = true;
-
-						if ( ev.type == sf::Event::JoystickMoved )
-							joy_guard = ev;
-						break;
-
-					case FeInputMap::Up:
-						if (( ev.type == sf::Event::JoystickMoved )
-								&& ( joy_guard.type == sf::Event::JoystickMoved ))
-							break;
-
-						if ( cursor_pos < (int)str.size() )
+						if ( did_delete )
 						{
-							if ( did_delete )
-							{
-								str.insert( cursor_pos, 1, my_char_table[0] );
-								redraw = true;
-								did_delete = false;
-							}
-							else
-							{
-								int idx = get_char_idx( str[cursor_pos] );
-
-								if ( my_char_table[idx+1] )
-								{
-									str[cursor_pos] = my_char_table[idx+1];
-									redraw = true;
-									did_delete = false;
-								}
-							}
-						}
-						else // allow inserting new characters at the end by pressing Up
-						{
-							str += my_char_table[0];
+							str.insert( cursor_pos, 1, my_char_table[0] );
 							redraw = true;
 							did_delete = false;
 						}
-
-						if ( ev.type == sf::Event::JoystickMoved )
-							joy_guard = ev;
-						break;
-
-					case FeInputMap::Down:
-						if (( ev.type == sf::Event::JoystickMoved )
-								&& ( joy_guard.type == sf::Event::JoystickMoved ))
-							break;
-
-						if ( did_delete ) // force user to do something else to confirm delete
-							break;
-
-						if ( cursor_pos < (int)str.size() )
+						else
 						{
 							int idx = get_char_idx( str[cursor_pos] );
 
-							if ( idx > 0 )
+							if ( my_char_table[idx+1] )
 							{
-								str[cursor_pos] = my_char_table[idx-1];
+								str[cursor_pos] = my_char_table[idx+1];
 								redraw = true;
-							}
-							else //if ( idx == 0 )
-							{
-								// Special case allowing the user to delete
-								// a character
-								str.erase( cursor_pos, 1 );
-								redraw = true;
-								did_delete = true;
+								did_delete = false;
 							}
 						}
-
-						if ( ev.type == sf::Event::JoystickMoved )
-							joy_guard = ev;
-						break;
-
-					case FeInputMap::Back:
-						return false;
-
-					case FeInputMap::Select:
-						return true;
-					default:
-						break;
 					}
+					else // allow inserting new characters at the end by pressing Up
+					{
+						str += my_char_table[0];
+						redraw = true;
+						did_delete = false;
+					}
+
+					if ( event->is<sf::Event::JoystickMoved>() )
+						joy_guard = *event;
+					break;
+
+				case FeInputMap::Down:
+					if ( event->is<sf::Event::JoystickMoved>()
+							&& joy_guard && joy_guard->is<sf::Event::JoystickMoved>() )
+						break;
+
+					if ( did_delete ) // force user to do something else to confirm delete
+						break;
+
+					if ( cursor_pos < (int)str.size() )
+					{
+						int idx = get_char_idx( str[cursor_pos] );
+
+						if ( idx > 0 )
+						{
+							str[cursor_pos] = my_char_table[idx-1];
+							redraw = true;
+						}
+						else //if ( idx == 0 )
+						{
+							// Special case allowing the user to delete
+							// a character
+							str.erase( cursor_pos, 1 );
+							redraw = true;
+							did_delete = true;
+						}
+					}
+
+					if ( event->is<sf::Event::JoystickMoved>() )
+						joy_guard = *event;
+					break;
+
+				case FeInputMap::Back:
+					return false;
+
+				case FeInputMap::Select:
+					return true;
+				default:
+					break;
 				}
-			break;
 			}
 
 			if ( redraw )
 			{
+				sf::FloatRect newBounds = cursor.getLocalBounds();
 				cursor.setPosition( tp->setString( str, cursor_pos ) - sf::Vector2f((
-					cursor.getLocalBounds().width + cursor.getLocalBounds().left - 2.0 ) * cursor.getScale().x,
-					cursor.getLocalBounds().top * cursor.getScale().y / 2.0 ));
+					newBounds.size.x + newBounds.position.x - 2.0 ) * cursor.getScale().x,
+					newBounds.position.y * cursor.getScale().y / 2.0 ));
 				cursor_timer.restart();
 			}
 		}
@@ -1940,11 +1924,7 @@ bool FeOverlay::edit_loop( std::vector<sf::Drawable *> d,
 
 		int cursor_fade = ( sin( cursor_timer.getElapsedTime().asMilliseconds() / 250.0 * M_PI ) + 1.0 ) * 255;
 
-#if ( SFML_VERSION_INT >= FE_VERSION_INT( 2, 4, 0 ) )
 		cursor.setFillColor( sf::Color( 255, 255, 255, std::max( 0, std::min( cursor_fade, 255 ))));
-#else
-		cursor.setColor( sf::Color( 255, 255, 255, std::max( 0, std::min( cursor_fade, 255 ))));
-#endif
 
 		m_wnd.draw( cursor, t );
 		m_wnd.display();
@@ -1957,16 +1937,17 @@ bool FeOverlay::edit_loop( std::vector<sf::Drawable *> d,
 		//
 		// Check if previous joystick move is now done (in which case we clear the guard)
 		//
-		if ( joy_guard.type == sf::Event::JoystickMoved )
+		if ( joy_guard && joy_guard->is<sf::Event::JoystickMoved>() )
 		{
 			sf::Joystick::update();
 
+			const auto* joyMoved = joy_guard->getIf<sf::Event::JoystickMoved>();
 			float pos = sf::Joystick::getAxisPosition(
-				joy_guard.joystickMove.joystickId,
-				joy_guard.joystickMove.axis );
+				joyMoved->joystickId,
+				joyMoved->axis );
 
 			if ( std::abs( pos ) < m_feSettings.get_joy_thresh() )
-				joy_guard = sf::Event();
+				joy_guard.reset();
 		}
 
 	}

--- a/src/fe_overlay.hpp
+++ b/src/fe_overlay.hpp
@@ -64,7 +64,7 @@ private:
 	bool event_loop( FeEventLoopCtx & );
 
 	bool edit_loop( std::vector<sf::Drawable *> draw_list,
-			std::basic_string<sf::Uint32> &str, FeTextPrimative *lb );
+			std::basic_string<std::uint32_t> &str, FeTextPrimative *lb );
 
 public:
 	FeOverlay( FeWindow &wnd,

--- a/src/fe_present.cpp
+++ b/src/fe_present.cpp
@@ -121,13 +121,13 @@ void FeFontContainer::set_font( const std::string &p, const std::string &n )
 		zs->open( n );
 		m_stream = zs;
 
-		if ( !m_font.loadFromStream( *m_stream ) )
+		if ( !m_font.openFromStream( *m_stream ) )
 			FeLog() << "Error loading font: " << p << "[" << n << "]" << std::endl;
 	}
 	else
 	{
 		m_stream = new FeFileInputStream( p + n );
-		if ( !m_font.loadFromStream( *m_stream ) )
+		if ( !m_font.openFromStream( *m_stream ) )
 			FeLog() << "Error loading font from file: " << p + n << std::endl;
 	}
 }
@@ -136,7 +136,7 @@ const sf::Font &FeFontContainer::get_font() const
 {
 	if ( m_needs_reload && m_stream )
 	{
-		m_font.loadFromStream( *m_stream );
+		m_font.openFromStream( *m_stream );
 		m_needs_reload=false;
 	}
 
@@ -366,8 +366,7 @@ void FePresent::init_monitors()
 					si[i].height );
 
 				mon.transform = sf::Transform().translate(
-					si[i].x_org,
-					si[i].y_org );
+					sf::Vector2f( si[i].x_org, si[i].y_org ) );
 
 				FeDebug() << "Multimon: monitor #" << si[i].screen_number
 					<< ": " << mon.size.x << "x" << mon.size.y << " @ "
@@ -1283,7 +1282,7 @@ bool FePresent::saver_activation_check()
 	//
 	// THis means the layout is forced by AM to reset after about a month of running
 	//
-	if ( m_layoutTimer.getElapsedTime().asMilliseconds() > std::numeric_limits<sf::Int32>::max() - 10000 )
+	if ( m_layoutTimer.getElapsedTime().asMilliseconds() > std::numeric_limits<std::int32_t>::max() - 10000 )
 		load_layout();
 
 	return false;
@@ -1331,7 +1330,7 @@ void FePresent::pre_run()
 				its != m_sounds.end(); ++its )
 		(*its)->release_audio( true );
 
-	sf::AudioDevice::release_audio( true );
+	// sf::AudioDevice::release_audio( true ); // SFML 3: removed custom audio device management
 #endif
 }
 
@@ -1343,7 +1342,7 @@ void FePresent::post_run()
 	//
 	// Re-establish openAL stuff now that we are back from the emulator
 	//
-	sf::AudioDevice::release_audio( false );
+	// sf::AudioDevice::release_audio( false ); // SFML 3: removed custom audio device management
 
 	for ( std::vector<FeBaseTextureContainer *>::iterator itm=m_texturePool.begin();
 				itm != m_texturePool.end(); ++itm )
@@ -1441,13 +1440,13 @@ void FePresent::set_transforms()
 
 			if ( actualRotation == FeSettings::RotateRight )
 			{
-				m_transform.translate( m_mon[0].size.x - adjust_x, adjust_y );
-				m_transform.rotate(90);
+				m_transform.translate( sf::Vector2f( m_mon[0].size.x - adjust_x, adjust_y ) );
+				m_transform.rotate( sf::degrees(90) );
 			}
 			else
 			{
-				m_transform.translate( adjust_x, m_mon[0].size.y - adjust_y );
-				m_transform.rotate(270);
+				m_transform.translate( sf::Vector2f( adjust_x, m_mon[0].size.y - adjust_y ) );
+				m_transform.rotate( sf::degrees(270) );
 			}
 		}
 		else
@@ -1459,12 +1458,12 @@ void FePresent::set_transforms()
 			float adjust_x = (m_layoutSize.x * m_layoutScale.x - m_mon[0].size.x) / 2;
 			float adjust_y = (m_layoutSize.y * m_layoutScale.y - m_mon[0].size.y) / 2;
 			if ( actualRotation == FeSettings::RotateNone )
-				m_transform.translate( -adjust_x, -adjust_y );
+				m_transform.translate( sf::Vector2f( -adjust_x, -adjust_y ) );
 			else
 			{
 				m_transform.translate(
-						m_mon[0].size.x + adjust_x, m_mon[0].size.y + adjust_y );
-				m_transform.rotate(180);
+						sf::Vector2f( m_mon[0].size.x + adjust_x, m_mon[0].size.y + adjust_y ) );
+				m_transform.rotate( sf::degrees(180) );
 			}
 		}
 	}
@@ -1479,27 +1478,27 @@ void FePresent::set_transforms()
 			break;
 
 		case FeSettings::RotateRight:
-			m_transform.translate( m_mon[0].size.x, 0 );
-			m_transform.scale( (float) m_mon[0].size.x / m_mon[0].size.y,
-				(float) m_mon[0].size.y / m_mon[0].size.x );
-			m_transform.rotate(90);
+			m_transform.translate( sf::Vector2f( m_mon[0].size.x, 0 ) );
+			m_transform.scale( sf::Vector2f( (float) m_mon[0].size.x / m_mon[0].size.y,
+				(float) m_mon[0].size.y / m_mon[0].size.x ) );
+			m_transform.rotate( sf::degrees(90) );
 			break;
 
 		case FeSettings::RotateLeft:
-			m_transform.translate( 0, m_mon[0].size.y );
-			m_transform.scale( (float) m_mon[0].size.x / m_mon[0].size.y,
-				(float) m_mon[0].size.y / m_mon[0].size.x );
-			m_transform.rotate(270);
+			m_transform.translate( sf::Vector2f( 0, m_mon[0].size.y ) );
+			m_transform.scale( sf::Vector2f( (float) m_mon[0].size.x / m_mon[0].size.y,
+				(float) m_mon[0].size.y / m_mon[0].size.x ) );
+			m_transform.rotate( sf::degrees(270) );
 			break;
 
 		case FeSettings::RotateFlip:
-			m_transform.translate( m_mon[0].size.x, m_mon[0].size.y );
-			m_transform.rotate(180);
+			m_transform.translate( sf::Vector2f( m_mon[0].size.x, m_mon[0].size.y ) );
+			m_transform.rotate( sf::degrees(180) );
 			break;
 		}
 	}
 
-	m_transform.scale( m_layoutScale.x, m_layoutScale.y );
+	m_transform.scale( sf::Vector2f( m_layoutScale.x, m_layoutScale.y ) );
 
 	for ( std::vector<FeBasePresentable *>::iterator itr=m_mon[0].elements.begin();
 			itr!=m_mon[0].elements.end(); ++itr )

--- a/src/fe_presentable.cpp
+++ b/src/fe_presentable.cpp
@@ -22,6 +22,7 @@
 
 #include "fe_presentable.hpp"
 #include "fe_present.hpp"
+#include <algorithm>
 
 FeBasePresentable::FeBasePresentable( FePresentableParent &p )
 	: m_parent( p ),

--- a/src/fe_romlist.cpp
+++ b/src/fe_romlist.cpp
@@ -30,6 +30,7 @@
 #include <squirrel.h>
 #include <sqstdstring.h>
 
+#include <SFML/System/Time.hpp>
 #include <SFML/System/Clock.hpp>
 
 const char *FE_ROMLIST_FILE_EXTENSION	= ".txt";

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -887,15 +887,15 @@ void FeSettings::init_mouse_capture( int window_x, int window_y )
 	int centre_x = window_x / 2;
 	int centre_y = window_y / 2;
 
-	m_mousecap_rect.left = centre_x - radius;
-	m_mousecap_rect.top = centre_y - radius;
-	m_mousecap_rect.width = radius * 2;
-	m_mousecap_rect.height = radius * 2;
+	m_mousecap_rect.position.x = centre_x - radius;
+	m_mousecap_rect.position.y = centre_y - radius;
+	m_mousecap_rect.size.x = radius * 2;
+	m_mousecap_rect.size.y = radius * 2;
 }
 
 bool FeSettings::test_mouse_reset( int mouse_x, int mouse_y ) const
 {
-	return (( m_inputmap.has_mouse_moves() ) && ( !m_mousecap_rect.contains( mouse_x, mouse_y ) ));
+	return (( m_inputmap.has_mouse_moves() ) && ( !m_mousecap_rect.contains( sf::Vector2i( mouse_x, mouse_y ) ) ));
 }
 
 int FeSettings::get_filter_index_from_offset( int offset ) const

--- a/src/fe_shader.cpp
+++ b/src/fe_shader.cpp
@@ -51,7 +51,7 @@ bool FeShader::load( sf::InputStream &sh,
 
 	m_type = t;
 	return m_shader.loadFromStream( sh,
-		(t == Fragment) ? sf::Shader::Fragment : sf::Shader::Vertex );
+		(t == Fragment) ? sf::Shader::Type::Fragment : sf::Shader::Type::Vertex );
 }
 
 bool FeShader::load( const std::string &vert_shader,
@@ -74,7 +74,7 @@ bool FeShader::load( const std::string &sh,
 
 	m_type = t;
 	return m_shader.loadFromFile( sh,
-		(t == Fragment) ? sf::Shader::Fragment : sf::Shader::Vertex );
+		(t == Fragment) ? sf::Shader::Type::Fragment : sf::Shader::Type::Vertex );
 }
 
 void FeShader::set_param( const char *name, float x )

--- a/src/fe_util.cpp
+++ b/src/fe_util.cpp
@@ -40,6 +40,7 @@
 #include <dirent.h>
 
 #include <SFML/Config.hpp>
+#include <SFML/System/Time.hpp>
 #include <SFML/System/Sleep.hpp>
 #include <SFML/System/Clock.hpp>
 
@@ -850,12 +851,12 @@ namespace
 		//
 		sf::Clock t;
 		while (( hotkey.get_current_state( opt->joy_thresh ) )
-			&& ( t.getElapsedTime().asMilliseconds() < TIMEOUT_MS ))
+			&& ( t.getElapsedTime().asMicroseconds() < TIMEOUT_MS * 1000 ))
 		{
 			if ( opt->wait_cb )
 				opt->wait_cb( opt->launch_opaque );
 
-			sf::sleep( sf::milliseconds( 10 ) );
+			sf::sleep( sf::microseconds( 10000 ) );
 		}
 
 		return true;
@@ -929,7 +930,7 @@ void windows_wait_process(
 
 				// Sleep to let the other process deal with the hiding of its window
 				// before we suspend it
-				sf::sleep( sf::milliseconds( 600 ) );
+				sf::sleep( sf::microseconds( 600000 ) );
 
 				// Undocumented windows system call
 				NtSuspendProcess pfn_NtSuspendProcess = (NtSuspendProcess)GetProcAddress(
@@ -978,7 +979,7 @@ void unix_wait_process( unsigned int pid, run_program_options_class *opt )
 				// uses to exit, we often have a problem of losing focus.  Delaying a bit and testing to make sure
 				// the emulator process is still running before sending the kill signal seems to help...
 				//
-				sf::sleep( sf::milliseconds( 100 ) );
+				sf::sleep( sf::microseconds( 100000 ) );
 				if ( kill( pid, 0 ) == 0 )
 				{
 					FeLog() << " - Exit Hotkey pressed, sending SIGTERM signal to process " << pid << std::endl;
@@ -990,10 +991,10 @@ void unix_wait_process( unsigned int pid, run_program_options_class *opt )
 					const int TERM_TIMEOUT = 1500;
 					sf::Clock term_clock;
 
-					while (( term_clock.getElapsedTime().asMilliseconds() < TERM_TIMEOUT )
+					while (( term_clock.getElapsedTime().asMicroseconds() < TERM_TIMEOUT * 1000 )
 						&& ( waitpid( pid, &status, WNOHANG ) == 0 ))
 					{
-						sf::sleep( sf::milliseconds( POLL_FOR_EXIT_MS ) );
+						sf::sleep( sf::microseconds( POLL_FOR_EXIT_MS * 1000 ) );
 					}
 
 					//
@@ -1033,14 +1034,14 @@ void unix_wait_process( unsigned int pid, run_program_options_class *opt )
 
 				// Sleep to let the other process deal with the unmapping of its window
 				// before we SIGSTOP it
-				sf::sleep( sf::milliseconds( 600 ) );
+				sf::sleep( sf::microseconds( 600000 ) );
 #endif
 				opt->running_pid = pid;
 				kill( pid, SIGSTOP );
 				break; // leave do/while loop
 			}
 
-			sf::sleep( sf::milliseconds( POLL_FOR_EXIT_MS ) );
+			sf::sleep( sf::microseconds( POLL_FOR_EXIT_MS * 1000 ) );
 		}
 		else
 		{
@@ -1403,9 +1404,9 @@ std::string name_with_brackets_stripped( const std::string &name )
 }
 
 
-std::basic_string<sf::Uint32> clipboard_get_content()
+std::basic_string<std::uint32_t> clipboard_get_content()
 {
-	std::basic_string<sf::Uint32> retval;
+	std::basic_string<std::uint32_t> retval;
 
 #ifdef SFML_SYSTEM_MACOS
 	retval = osx_clipboard_get_content();

--- a/src/fe_util.hpp
+++ b/src/fe_util.hpp
@@ -25,6 +25,7 @@
 
 #include <vector>
 #include <string>
+#include <cstdint>
 #include <SFML/Config.hpp>
 
 #ifdef FE_DEBUG
@@ -280,7 +281,7 @@ const char *get_OS_string();
 //
 // return the contents of the clipboard (if implemented for OS)
 //
-std::basic_string<sf::Uint32> clipboard_get_content();
+std::basic_string<std::uint32_t> clipboard_get_content();
 
 //
 // We use this in fe_window but implement it here because the XWindows

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -50,6 +50,7 @@
 #include <stdio.h>
 #include <ctime>
 #include <stdarg.h>
+#include <algorithm>
 
 const char *FE_SCRIPT_NV_FILE = "script.nv";
 
@@ -123,13 +124,13 @@ namespace
 				// problem...
 				//
 				int i=0;
-				while (( i < zip.getSize() ) && ( d[i] < 32 ))
+				while (( i < zip.getSize().value() ) && ( d[i] < 32 ))
 					i++;
 
-				if ( i == zip.getSize() )
+				if ( i == zip.getSize().value() )
 					return false;
 
-				std::string str( &(d[i]), zip.getSize()-i );
+				std::string str( &(d[i]), zip.getSize().value()-i );
 				sc.CompileString( str );
 			}
 			else
@@ -373,37 +374,37 @@ void FeVM::set_overlay( FeOverlay *feo )
 	m_overlay = feo;
 }
 
-bool FeVM::poll_command( FeInputMap::Command &c, sf::Event &ev, bool &from_ui )
+FePollCommandResult FeVM::poll_command()
 {
-	from_ui=false;
+	FePollCommandResult r;
+	r.from_ui = false;
 
 	if ( !m_posted_commands.empty() )
 	{
-		c = (FeInputMap::Command)m_posted_commands.front();
+		r.command = (FeInputMap::Command)m_posted_commands.front();
 		m_posted_commands.pop();
-		ev.type = sf::Event::Count;
 
-		return true;
+		return r;
 	}
-	else if ( m_window.pollEvent( ev ) )
+
+	std::optional<sf::Event> ev = m_window.pollEvent();
+	if ( ev )
 	{
 		int t = m_layoutTimer.getElapsedTime().asMilliseconds();
 
-		// Debounce to stop multiples when triggered by a key combo
-		//
 		if ( t - m_last_ui_cmd.asMilliseconds() < 30 )
-			return false;
+			return FePollCommandResult(); // empty result
 
-		c = m_feSettings->map_input( ev );
+		r.command = m_feSettings->map_input( *ev );
 
-		if ( c != FeInputMap::LAST_COMMAND )
+		if ( r.command != FeInputMap::LAST_COMMAND )
 			m_last_ui_cmd = m_layoutTimer.getElapsedTime();
 
-		from_ui = true;
-		return true;
+		r.from_ui = true;
+		r.event = ev;
 	}
 
-	return false;
+	return r;
 }
 
 void FeVM::clear()
@@ -1291,8 +1292,7 @@ void FeVM::on_transition(
 			// TODO: It is probably a good idea to do this for
 			// every platform... needs investigation.
 			//
-			sf::Event ev;
-			while (m_window.pollEvent(ev))
+			while (m_window.pollEvent())
 			{
 				//sf::sleep( sf::milliseconds( 10 ) );
 			}

--- a/src/fe_vm.hpp
+++ b/src/fe_vm.hpp
@@ -26,12 +26,22 @@
 #include <vector>
 #include <queue>
 #include <string>
+#include <optional>
 
 #include "fe_input.hpp"
 #include "fe_present.hpp"
 
+#include <SFML/Window/Event.hpp>
+
 #include <sqrat/sqratObject.h>
 #include <sqrat/sqratFunction.h>
+
+struct FePollCommandResult
+{
+	FeInputMap::Command command;
+	bool from_ui;
+	std::optional<sf::Event> event;
+};
 
 class FeWindow;
 class FeOverlay;
@@ -116,7 +126,7 @@ public:
 	void set_overlay( FeOverlay *feo );
 
 	void flag_redraw() { m_redraw_triggered = true; };
-	bool poll_command( FeInputMap::Command &c, sf::Event &ev, bool &from_ui );
+	FePollCommandResult poll_command();
 	void clear(); // override of base class clear()
 
 	void update_to_new_list( int var=0, bool reset_display=false, bool suppress_transition=false ); // NOTE: override virtual function from FePresent

--- a/src/fe_window.cpp
+++ b/src/fe_window.cpp
@@ -164,10 +164,18 @@ void FeWindow::initial_create()
 #if defined(SFML_SYSTEM_WINDOWS) && !defined(WINDOWS_XP)
 		sf::Style::None,       // FeSettings::Fullscreen
 #else
-		sf::Style::Fullscreen, // FeSettings::Fullscreen
+		sf::Style::None,       // FeSettings::Fullscreen
 #endif
 		sf::Style::Default,    // FeSettings::Window
 		sf::Style::None        // FeSettings::WindowNoBorder
+	};
+
+	sf::State state_map[4] =
+	{
+		sf::State::Windowed,   // FeSettings::Default
+		sf::State::Fullscreen, // FeSettings::Fullscreen
+		sf::State::Windowed,   // FeSettings::Window
+		sf::State::Windowed    // FeSettings::WindowNoBorder
 	};
 
 	sf::VideoMode vm = sf::VideoMode::getDesktopMode(); // width/height/bpp of OpenGL surface to create
@@ -193,7 +201,7 @@ void FeWindow::initial_create()
 		// (it is positioned to accomodate window decoration that isn't there).  setPosition()
 		// doesn't work
 		//
-		get_x11_primary_screen_size( vm.width, vm.height );
+		get_x11_primary_screen_size( vm.size.x, vm.size.y );
 	}
 	else
 	{
@@ -202,7 +210,7 @@ void FeWindow::initial_create()
 		// keeping it though because it has been needed historically (earlier versions of SFML,
 		// other window managers etc) and it seems to lead to the same results
 		//
-		get_x11_multimon_geometry( wpos.x, wpos.y, vm.width, vm.height );
+		get_x11_multimon_geometry( wpos.x, wpos.y, vm.size.x, vm.size.y );
 	}
 
 #elif defined(SFML_SYSTEM_WINDOWS)
@@ -223,7 +231,7 @@ void FeWindow::initial_create()
 	// Windows API call to undo the WS_POPUP Style.  Seems to require a ShowWindow() call
 	// afterwards to take effect:
 	//
-	//		SetWindowLongPtr( getSystemHandle(), GWL_STYLE,
+	//		SetWindowLongPtr( getNativeHandle(), GWL_STYLE,
 	//			WS_BORDER | WS_CLIPCHILDREN | WS_CLIPSIBLINGS );
 	//
 
@@ -251,8 +259,8 @@ void FeWindow::initial_create()
 		wpos.x = GetSystemMetrics( SM_XVIRTUALSCREEN );
 		wpos.y = GetSystemMetrics( SM_YVIRTUALSCREEN );
 
-		vm.width = GetSystemMetrics( SM_CXVIRTUALSCREEN );
-		vm.height = GetSystemMetrics( SM_CYVIRTUALSCREEN );
+		vm.size.x = GetSystemMetrics( SM_CXVIRTUALSCREEN );
+		vm.size.y = GetSystemMetrics( SM_CYVIRTUALSCREEN );
 	}
 
 	// Some Windows users are reporting emulators hanging/failing to get focus when launched
@@ -270,8 +278,8 @@ void FeWindow::initial_create()
 	{
 		wpos.x -= 1;
 		wpos.y -= 1;
-		vm.width += 2;
-		vm.height += 2;
+		vm.size.x += 2;
+		vm.size.y += 2;
 	}
 
 #endif
@@ -288,11 +296,11 @@ void FeWindow::initial_create()
 		win_pos.load_from_file( m_fes.get_config_dir() + FeWindowPosition::FILENAME );
 
 		wpos = win_pos.m_pos;
-		vm.width = win_pos.m_size.x;
-		vm.height = win_pos.m_size.y;
+		vm.size.x = win_pos.m_size.x;
+		vm.size.y = win_pos.m_size.y;
 	}
 
-	sf::Vector2u wsize( vm.width, vm.height );
+	sf::Vector2u wsize( vm.size.x, vm.size.y );
 
 #if defined(SFML_SYSTEM_WINDOWS)
 	// To avoid problems with black screen on launching games when window mode is set to Fullscreen
@@ -303,7 +311,7 @@ void FeWindow::initial_create()
 	if ( m_win_mode == FeSettings::Fullscreen )
 	{
 		m_blackout.create(sf::VideoMode(16, 16, 24), "", sf::Style::None);
-		m_blackout.setSize( sf::Vector2u( vm.width + 2, vm.height + 2 ));
+		m_blackout.setSize( sf::Vector2u( vm.size.x + 2, vm.size.y + 2 ));
 		m_blackout.setPosition( sf::Vector2i( -1, -1 ));
 		m_blackout.setVerticalSyncEnabled(true);
 		m_blackout.setKeyRepeatEnabled(false);
@@ -311,8 +319,8 @@ void FeWindow::initial_create()
 
 
 		// We hide the black window from the task bar and the alt+tab switcher
-		int style = GetWindowLongPtr(m_blackout.getSystemHandle(), GWL_EXSTYLE );
-		SetWindowLongPtr( m_blackout.getSystemHandle(), GWL_EXSTYLE, style | WS_EX_TOOLWINDOW );
+		int style = GetWindowLongPtr(m_blackout.getNativeHandle(), GWL_EXSTYLE );
+		SetWindowLongPtr( m_blackout.getNativeHandle(), GWL_EXSTYLE, style | WS_EX_TOOLWINDOW );
 		m_blackout.clear();
 		m_blackout.display();
 	}
@@ -321,7 +329,7 @@ void FeWindow::initial_create()
 	//
 	// Create window
 	//
-	m_window->create( vm, "Attract-Mode", style_map[ m_win_mode ] );
+	m_window->create( vm, "Attract-Mode", style_map[ m_win_mode ], state_map[ m_win_mode ] );
 
 	// On Windows Vista and above all non fullscreen window modes
 	// go through DWM. We have to disable vsync
@@ -350,7 +358,7 @@ void FeWindow::initial_create()
 
 #if defined(USE_XLIB)
 	if ( m_win_mode == FeSettings::Default )
-		set_x11_fullscreen_state( m_window->getSystemHandle() );
+		set_x11_fullscreen_state( m_window->getNativeHandle() );
 #endif
 
 	// Known issue: Linux Mint 18.3 Cinnamon w/ SFML 2.5.1, position isn't being set
@@ -359,7 +367,7 @@ void FeWindow::initial_create()
 
 	FeDebug() << "Created Attract-Mode Window: " << wsize.x << "x" << wsize.y << " @ "
 		<< wpos.x << "," << wpos.y << " [OpenGL surface: "
-		<< vm.width << "x" << vm.height << " bpp=" << vm.bitsPerPixel << "]" << std::endl;
+		<< vm.size.x << "x" << vm.size.y << " bpp=" << vm.bitsPerPixel << "]" << std::endl;
 
 #if defined(SFML_SYSTEM_WINDOWS)
 
@@ -372,11 +380,11 @@ void FeWindow::initial_create()
 	if (( m_win_mode == FeSettings::WindowNoBorder )
 		&& ( wpos.x == 0 )
 		&& ( wpos.y == 0 )
-		&& ( vm.width == wsize.x )
-		&& ( vm.height == wsize.y ))
+		&& ( vm.size.x == wsize.x )
+		&& ( vm.size.y == wsize.y ))
 		m_win_mode = FeSettings::Fullscreen;
 #endif
-	set_win32_foreground_window( m_window->getSystemHandle(), HWND_TOP );
+	set_win32_foreground_window( m_window->getNativeHandle(), HWND_TOP );
 #endif
 
 	m_fes.init_mouse_capture( wsize.x, wsize.y );
@@ -411,10 +419,9 @@ void wait_callback( void *o )
 
 	if ( win->isOpen() )
 	{
-		sf::Event ev;
-		while ( win->pollEvent( ev ) )
+		while ( auto event = win->pollEvent() )
 		{
-			if ( ev.type == sf::Event::Closed )
+			if ( event->is<sf::Event::Closed>() )
 				return;
 		}
 	}
@@ -480,14 +487,14 @@ bool FeWindow::run()
 #if defined(SFML_SYSTEM_WINDOWS)
 	if ( m_win_mode == FeSettings::Fullscreen )
 	{
-		set_win32_foreground_window( m_window->getSystemHandle(), HWND_BOTTOM );
+		set_win32_foreground_window( m_window->getNativeHandle(), HWND_BOTTOM );
 		m_blackout.display();
 		m_window->setVisible( false );
-		set_win32_foreground_window( m_blackout.getSystemHandle(), HWND_TOP );
+		set_win32_foreground_window( m_blackout.getNativeHandle(), HWND_TOP );
 	}
 	else
 	{
-		set_win32_foreground_window( m_window->getSystemHandle(), HWND_TOP );
+		set_win32_foreground_window( m_window->getNativeHandle(), HWND_TOP );
 		if ( !is_multimon_config( m_fes ))
 			clear();
 		display();
@@ -552,12 +559,9 @@ bool FeWindow::run()
 
 		while ( !done_wait && isOpen() )
 		{
-			sf::Event ev;
-
-#if ( SFML_VERSION_INT >= FE_VERSION_INT( 2, 2, 0 ))
-			while (pollEvent(ev))
+			while ( const std::optional event = pollEvent() )
 			{
-				if ( ev.type == sf::Event::Closed )
+				if ( event->is<sf::Event::Closed>() )
 					return false;
 			}
 
@@ -565,34 +569,6 @@ bool FeWindow::run()
 			has_focus = hasFocus() || m_blackout.hasFocus();
 #else
 			has_focus = hasFocus();
-#endif
-
-#else
-			//
-			// flakey pre-SFML 2.2 implementation
-			// to be removed if SFML 2.0/2.1 support is ever dropped
-			//
-			while (pollEvent(ev))
-			{
-				if ( ev.type == sf::Event::GainedFocus )
-				{
-					if ( !has_focus )
-						FeDebug() << "Gained focus at "
-							<< timer.getElapsedTime().asMilliseconds() << "ms" << std::endl;
-
-					has_focus = true;
-				}
-				else if ( ev.type == sf::Event::LostFocus )
-				{
-					if ( has_focus )
-						FeDebug() << "Lost focus at "
-							<< timer.getElapsedTime().asMilliseconds() << "ms" << std::endl;
-
-					has_focus = false;
-				}
-				else if ( ev.type == sf::Event::Closed )
-					return false;
-			}
 #endif
 
 			if (( timer.getElapsedTime() >= sf::seconds( nbm_wait ) )
@@ -635,7 +611,7 @@ bool FeWindow::run()
  #endif
 	}
  #if defined(USE_XLIB)
-	set_x11_foreground_window( m_window->getSystemHandle() );
+	set_x11_foreground_window( m_window->getNativeHandle() );
  #endif
 
 #elif defined(SFML_SYSTEM_MACOS)
@@ -654,10 +630,10 @@ bool FeWindow::run()
 			clear();
 			display();
 		}
-		set_win32_foreground_window( m_window->getSystemHandle(), HWND_TOP );
+		set_win32_foreground_window( m_window->getNativeHandle(), HWND_TOP );
 	}
 	else
-		set_win32_foreground_window( m_window->getSystemHandle(), HWND_TOP );
+		set_win32_foreground_window( m_window->getNativeHandle(), HWND_TOP );
 #endif
 
 	if ( m_fes.get_info_bool( FeSettings::MoveMouseOnLaunch ) )
@@ -665,13 +641,11 @@ bool FeWindow::run()
 
 	// Empty the window event queue, so we don't go triggering other
 	// right away after running an emulator
-	sf::Event ev;
-
-	while (isOpen() && pollEvent(ev))
+	while (isOpen() && pollEvent())
 	{
-		if ( ev.type == sf::Event::Closed )
-			return false;
 	}
+
+	return true;
 
 	FeDebug() << "Resuming frontend after game launch" << std::endl;
 
@@ -738,10 +712,10 @@ void FeWindow::draw( const sf::Drawable &d, const sf::RenderStates &r )
 		m_window->draw( d, r );
 }
 
-bool FeWindow::pollEvent( sf::Event &e )
+std::optional<sf::Event> FeWindow::pollEvent()
 {
 	if ( m_window )
-		return m_window->pollEvent( e );
+		return m_window->pollEvent();
 
-	return false;
+	return std::nullopt;
 }

--- a/src/fe_window.hpp
+++ b/src/fe_window.hpp
@@ -62,7 +62,7 @@ public:
 
 	void clear();
 	void draw( const sf::Drawable &d, const sf::RenderStates &t=sf::RenderStates::Default );
-	bool pollEvent( sf::Event &e );
+	std::optional<sf::Event> pollEvent();
 
 	sf::RenderWindow &get_win();
 };

--- a/src/image_loader.cpp
+++ b/src/image_loader.cpp
@@ -49,17 +49,24 @@ namespace
 	int read(void* user, char* data, int size)
 	{
 		sf::InputStream* stream = static_cast<sf::InputStream*>(user);
-		return static_cast<int>(stream->read(data, size));
+		auto result = stream->read(data, size);
+		return result ? static_cast<int>(*result) : -1;
 	}
 	void skip(void* user, int size)
 	{
 		sf::InputStream* stream = static_cast<sf::InputStream*>(user);
-		stream->seek(stream->tell() + size);
+		auto pos = stream->tell();
+		if (pos)
+			stream->seek(*pos + size);
 	}
 	int eof(void* user)
 	{
 		sf::InputStream* stream = static_cast<sf::InputStream*>(user);
-		return stream->tell() >= stream->getSize();
+		auto pos = stream->tell();
+		auto size = stream->getSize();
+		if (pos && size)
+			return *pos >= *size;
+		return 1;
 	}
 	std::recursive_mutex g_mutex;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -188,7 +188,7 @@ int main(int argc, char *argv[])
 	FeInputMap::Command move_state( FeInputMap::LAST_COMMAND ); // command mapped to the move
 	FeInputMap::Command move_triggered( FeInputMap::LAST_COMMAND ); // "repeatable" command triggered on move (if any)
 	sf::Clock move_timer;
-	sf::Event move_event;
+	std::optional<sf::Event> move_event;
 	int move_last_triggered( 0 );
 	sf::Vector2i last_mouse_pos;
 
@@ -345,72 +345,56 @@ int main(int argc, char *argv[])
 			redraw=true;
 		}
 
-		sf::Event ev;
-		bool from_ui;
-		while ( feVM.poll_command( c, ev, from_ui ) )
+		FePollCommandResult r;
+		while ( ( r = feVM.poll_command() ).command != FeInputMap::LAST_COMMAND || r.event )
 		{
-			//
-			// Special case handling based on event type
-			//
-			switch ( ev.type )
+			if ( r.event )
 			{
-				case sf::Event::Closed:
-					exit_selected = true;
-					break;
+				sf::Event &ev = *r.event;
 
-				case sf::Event::MouseMoved:
-					if ( (( ev.mouseMove.x != last_mouse_pos.x ) || ( ev.mouseMove.y != last_mouse_pos.y ))
-						&& ( feSettings.test_mouse_reset( ev.mouseMove.x, ev.mouseMove.y )) )
+				if ( ev.is<sf::Event::Closed>() )
+				{
+					exit_selected = true;
+				}
+				else if ( ev.is<sf::Event::MouseMoved>() )
+				{
+					auto* mm = ev.getIf<sf::Event::MouseMoved>();
+					if ( (( mm->position.x != last_mouse_pos.x ) || ( mm->position.y != last_mouse_pos.y ))
+						&& ( feSettings.test_mouse_reset( mm->position.x, mm->position.y )) )
 					{
-						// We reset the mouse if we are capturing it and it has moved
-						// outside of its bounding box
-						//
-						last_mouse_pos = sf::Vector2i( ev.mouseMove.x, ev.mouseMove.y );
+						last_mouse_pos = sf::Vector2i( mm->position.x, mm->position.y );
 						sf::Vector2u s = window.get_win().getSize();
 						sf::Mouse::setPosition( sf::Vector2i( s.x / 2, s.y / 2 ), window.get_win() );
 					}
-					break;
-
-				case sf::Event::KeyReleased:
-				case sf::Event::MouseButtonReleased:
-				case sf::Event::JoystickButtonReleased:
-					//
-					// We always want to reset the screen saver on these events,
-					// even if they aren't mapped otherwise (mapped events cause
-					// a reset too)
-					//
-					if (( c == FeInputMap::LAST_COMMAND )
+				}
+				else if ( ev.is<sf::Event::KeyReleased>() ||
+						ev.is<sf::Event::MouseButtonReleased>() ||
+						ev.is<sf::Event::JoystickButtonReleased>() )
+				{
+					if (( r.command == FeInputMap::LAST_COMMAND )
 							&& ( feVM.reset_screen_saver() ))
 						redraw = true;
-					break;
-
-				case sf::Event::GainedFocus:
-				case sf::Event::Resized:
+				}
+				else if ( ev.is<sf::Event::FocusGained>() || ev.is<sf::Event::Resized>() )
+				{
 					redraw = true;
-					break;
-
-
-				case sf::Event::JoystickMoved:
-					if ( c != FeInputMap::LAST_COMMAND )
+				}
+				else if ( ev.is<sf::Event::JoystickMoved>() )
+				{
+					if ( r.command != FeInputMap::LAST_COMMAND )
 					{
-						// Only allow one mapped "Joystick Moved" input through at a time
-						//
 						if ( guard_joyid != -1 )
 							continue;
 
-						guard_joyid = ev.joystickMove.joystickId;
-						guard_axis = ev.joystickMove.axis;
+						auto* jm = ev.getIf<sf::Event::JoystickMoved>();
+						guard_joyid = jm->joystickId;
+						guard_axis = static_cast<int>(jm->axis);
 					}
-					break;
-
-				case sf::Event::JoystickConnected:
-				case sf::Event::JoystickDisconnected:
+				}
+				else if ( ev.is<sf::Event::JoystickConnected>() || ev.is<sf::Event::JoystickDisconnected>() )
+				{
 					feSettings.on_joystick_connect();
-					break;
-
-				case sf::Event::Count:
-				default:
-					break;
+				}
 			}
 
 			// Test if we need to keep the joystick axis guard up
@@ -451,15 +435,15 @@ int main(int argc, char *argv[])
 			// let the signal proceed (and set move_triggered below... at step 2 of 2)
 			//
 			if (( move_state != FeInputMap::LAST_COMMAND )
-					&& ( from_ui || ( move_triggered != FeInputMap::LAST_COMMAND )))
+					&& ( r.from_ui || ( move_triggered != FeInputMap::LAST_COMMAND )))
 				continue;
 
-			if ( from_ui )
+			if ( r.from_ui )
 			{
 				// setup variables to test for when the navigation keys are held down
-				move_state = c;
+				move_state = r.command;
 				move_timer.restart();
-				move_event = ev;
+				move_event = r.event;
 				move_triggered = FeInputMap::LAST_COMMAND;
 			}
 
@@ -590,7 +574,7 @@ int main(int argc, char *argv[])
 			//
 			// ( move_state == LAST_COMMAND ) will catch the regular case with no remapping
 			//
-			if (( !from_ui && ( move_triggered == FeInputMap::LAST_COMMAND ))
+			if (( !r.from_ui && ( move_triggered == FeInputMap::LAST_COMMAND ))
 					|| ( move_state != FeInputMap::LAST_COMMAND ))
 			{
 				if ( FeInputMap::is_repeatable_command( c ) )
@@ -652,7 +636,7 @@ int main(int argc, char *argv[])
 						sf::RenderWindow &w = window.get_win();
 #if ( SFML_VERSION_INT >= FE_VERSION_INT( 2, 4, 0 ) )
 						sf::Texture texture;
-						texture.create( w.getSize().x, w.getSize().y );
+						texture.resize( w.getSize() );
 						texture.update( w );
 						sf::Image sshot_img = texture.copyToImage();
 #else
@@ -913,39 +897,35 @@ int main(int argc, char *argv[])
 		{
 			bool cont=false;
 
-			switch ( move_event.type )
+			if ( move_event )
 			{
-			case sf::Event::KeyPressed:
-				if ( sf::Keyboard::isKeyPressed( move_event.key.code ) )
-					cont=true;
-				break;
-
-			case sf::Event::MouseButtonPressed:
-				if ( sf::Mouse::isButtonPressed( move_event.mouseButton.button ) )
-					cont=true;
-				break;
-
-			case sf::Event::JoystickButtonPressed:
-				if ( sf::Joystick::isButtonPressed(
-						move_event.joystickButton.joystickId,
-						move_event.joystickButton.button ) )
-					cont=true;
-				break;
-
-			case sf::Event::JoystickMoved:
+				if ( move_event->is<sf::Event::KeyPressed>() )
+				{
+					const auto* kp = move_event->getIf<sf::Event::KeyPressed>();
+					if ( sf::Keyboard::isKeyPressed( kp->code ) )
+						cont=true;
+				}
+				else if ( move_event->is<sf::Event::MouseButtonPressed>() )
+				{
+					const auto* mb = move_event->getIf<sf::Event::MouseButtonPressed>();
+					if ( sf::Mouse::isButtonPressed( mb->button ) )
+						cont=true;
+				}
+				else if ( move_event->is<sf::Event::JoystickButtonPressed>() )
+				{
+					const auto* jb = move_event->getIf<sf::Event::JoystickButtonPressed>();
+					if ( sf::Joystick::isButtonPressed( jb->joystickId, jb->button ) )
+						cont=true;
+				}
+				else if ( move_event->is<sf::Event::JoystickMoved>() )
 				{
 					sf::Joystick::update();
 
-					float pos = sf::Joystick::getAxisPosition(
-							move_event.joystickMove.joystickId,
-							move_event.joystickMove.axis );
+					const auto* jm = move_event->getIf<sf::Event::JoystickMoved>();
+					float pos = sf::Joystick::getAxisPosition( jm->joystickId, jm->axis );
 					if ( std::abs( pos ) > feSettings.get_joy_thresh() )
 						cont=true;
 				}
-				break;
-
-			default:
-				break;
 			}
 
 			if ( cont )

--- a/src/media.cpp
+++ b/src/media.cpp
@@ -48,6 +48,7 @@ extern "C"
 #include <thread>
 #include <mutex>
 #include <atomic>
+#include <algorithm>
 
 #if (LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT( 59, 0, 100 ))
 typedef const AVCodec FeAVCodec;
@@ -154,7 +155,7 @@ class FeAudioImp : public FeBaseStream
 {
 public:
 	SwrContext *resample_ctx;
-	sf::Int16 *audio_buff;
+	std::int16_t *audio_buff;
 	std::recursive_mutex audio_buff_mutex;
 
 	FeAudioImp();
@@ -176,7 +177,7 @@ private:
 	//
 	std::thread m_video_thread;
 	FeMedia *m_parent;
-	sf::Uint8 *rgba_buffer[4];
+	std::uint8_t *rgba_buffer[4];
 	int rgba_linesize[4];
 
 #if FE_HWACCEL
@@ -198,7 +199,7 @@ public:
 	// The main thread then copies the image into the corresponding sf::Texture.
 	//
 	std::recursive_mutex image_swap_mutex;
-	sf::Uint8 *display_frame;
+	std::uint8_t *display_frame;
 
 	FeVideoImp( FeMedia *parent );
 	~FeVideoImp();
@@ -341,8 +342,8 @@ bool FeAudioImp::process_frame( AVFrame *frame, sf::SoundStream::Chunk &data, in
 		std::lock_guard<std::recursive_mutex> l( audio_buff_mutex );
 
 		memcpy( (audio_buff + offset), frame->data[0], data_size );
-		offset += data_size / sizeof( sf::Int16 );
-		data.sampleCount += data_size / sizeof(sf::Int16);
+		offset += data_size / sizeof( std::int16_t );
+		data.sampleCount += data_size / sizeof(std::int16_t);
 		data.samples = audio_buff;
 	}
 	else
@@ -644,7 +645,7 @@ void FeVideoImp::video_thread()
 		//
 		if ( detached_frame )
 		{
-			wait_time = (sf::Int64)detached_frame->pts * time_base
+			wait_time = (std::int64_t)detached_frame->pts * time_base
 					- m_parent->get_video_time();
 
 			if ( wait_time < max_sleep )
@@ -965,12 +966,12 @@ int fe_media_read( void *opaque, uint8_t *buff, int buff_size )
 {
 	sf::InputStream *z = (sf::InputStream *)opaque;
 
-	sf::Int64 bytes_read = z->read( buff, buff_size );
+	std::optional<std::int64_t> bytes_read = z->read( buff, buff_size );
 
-	if ( bytes_read == 0 )
+	if ( !bytes_read || *bytes_read == 0 )
 		return AVERROR_EOF;
 
-	return bytes_read;
+	return *bytes_read;
 }
 
 // whence: SEEK_SET, SEEK_CUR, SEEK_END, and AVSEEK_SIZE
@@ -981,17 +982,35 @@ int64_t fe_media_seek( void *opaque, int64_t offset, int whence )
 	switch ( whence )
 	{
 	case AVSEEK_SIZE:
-		return z->getSize();
+		{
+			std::optional<std::uint64_t> size = z->getSize();
+			return size ? static_cast<int64_t>(*size) : AVERROR_EOF;
+		}
 
 	case SEEK_CUR:
-		return z->seek( z->tell() + offset );
+		{
+			std::optional<std::uint64_t> pos = z->tell();
+			if ( !pos )
+				return AVERROR_EOF;
+			std::optional<std::uint64_t> newPos = z->seek( *pos + offset );
+			return newPos ? static_cast<int64_t>(*newPos) : AVERROR_EOF;
+		}
 
 	case SEEK_END:
-		return z->seek( z->getSize() + offset );
+		{
+			std::optional<std::uint64_t> size = z->getSize();
+			if ( !size )
+				return AVERROR_EOF;
+			std::optional<std::uint64_t> newPos = z->seek( *size + offset );
+			return newPos ? static_cast<int64_t>(*newPos) : AVERROR_EOF;
+		}
 
 	case SEEK_SET:
 	default:
-		return z->seek( offset );
+		{
+			std::optional<std::uint64_t> newPos = z->seek( offset );
+			return newPos ? static_cast<int64_t>(*newPos) : AVERROR_EOF;
+		}
 	}
 }
 
@@ -1091,7 +1110,7 @@ bool FeMedia::open( const std::string &archive,
 				// TODO: Fix buffer sizing, we allocate way
 				// more than we use
 				//
-				m_audio->audio_buff = (sf::Int16 *)av_malloc(
+				m_audio->audio_buff = (std::int16_t *)av_malloc(
 					MAX_AUDIO_FRAME_SIZE
 					+ AV_INPUT_BUFFER_PADDING_SIZE
 					+ codec_ctx->sample_rate );
@@ -1201,9 +1220,9 @@ bool FeMedia::open( const std::string &archive,
 				m_video->disptex_width = FFALIGN( codec_ctx->width, 32 );
 				m_video->disptex_height = codec_ctx->height;
 
-				m_video->display_texture = outt;
-				if ( outt->getSize() != sf::Vector2u( m_video->disptex_width, m_video->disptex_height ) )
-					m_video->display_texture->create( m_video->disptex_width, m_video->disptex_height );
+m_video->display_texture = outt;
+			if ( outt->getSize() != sf::Vector2u( m_video->disptex_width, m_video->disptex_height ) )
+				m_video->display_texture->resize( sf::Vector2u( m_video->disptex_width, m_video->disptex_height ) );
 
 				m_video->init_rgba_buffer();
 			}

--- a/src/scraper_base.cpp
+++ b/src/scraper_base.cpp
@@ -128,8 +128,11 @@ std::string get_crc( const std::string &full_path,
 				zs.open( *itr );
 
 				char *buff = zs.getData();
-				int size = zs.getSize();
+				std::optional<std::size_t> optSize = zs.getSize();
+				if ( !optSize )
+					return "";
 
+				int size = *optSize;
 				if ( size > MAX_CRC_FILE_SIZE )
 					return "";
 

--- a/src/scraper_xml.cpp
+++ b/src/scraper_xml.cpp
@@ -32,6 +32,7 @@
 
 #include <expat.h>
 
+#include <SFML/System/Time.hpp>
 #include <SFML/System/Clock.hpp>
 
 //

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -63,7 +63,7 @@
 
 ////////////////////////////////////////////////////////////
 FeSprite::FeSprite() :
-m_vertices( sf::TrianglesStrip, 4 ),
+m_vertices( sf::PrimitiveType::TriangleStrip, 4 ),
 m_texture    (NULL),
 m_textureRect(),
 m_pinch( 0.f, 0.f ),
@@ -74,7 +74,7 @@ m_skew( 0.f, 0.f )
 
 ////////////////////////////////////////////////////////////
 FeSprite::FeSprite(const sf::Texture& texture) :
-m_vertices( sf::TrianglesStrip, 4 ),
+m_vertices( sf::PrimitiveType::TriangleStrip, 4 ),
 m_texture    (NULL),
 m_textureRect(),
 m_pinch( 0.f, 0.f ),
@@ -86,7 +86,7 @@ m_skew( 0.f, 0.f )
 
 ////////////////////////////////////////////////////////////
 FeSprite::FeSprite(const sf::Texture& texture, const sf::IntRect& rectangle) :
-m_vertices( sf::TrianglesStrip, 4 ),
+m_vertices( sf::PrimitiveType::TriangleStrip, 4 ),
 m_texture    (NULL),
 m_textureRect(),
 m_pinch( 0.f, 0.f ),
@@ -102,7 +102,7 @@ void FeSprite::setTexture(const sf::Texture& texture, bool resetRect)
 {
     // Recompute the texture area if requested, or if there was no valid texture & rect before
     if (resetRect || (!m_texture && (m_textureRect == sf::IntRect())))
-        setTextureRect(sf::IntRect(0, 0, texture.getSize().x, texture.getSize().y));
+        setTextureRect(sf::IntRect({0, 0}, {static_cast<int>(texture.getSize().x), static_cast<int>(texture.getSize().y)}));
 
     // Assign the new texture
     m_texture = &texture;
@@ -153,10 +153,10 @@ const sf::Color& FeSprite::getColor() const
 ////////////////////////////////////////////////////////////
 sf::FloatRect FeSprite::getLocalBounds() const
 {
-    float width = static_cast<float>(std::abs(m_textureRect.width));
-    float height = static_cast<float>(std::abs(m_textureRect.height));
+    float width = static_cast<float>(std::abs(m_textureRect.size.x));
+    float height = static_cast<float>(std::abs(m_textureRect.size.y));
 
-    return sf::FloatRect(0.f, 0.f, width, height);
+    return sf::FloatRect({0.f, 0.f}, {width, height});
 }
 
 
@@ -248,10 +248,10 @@ void FeSprite::updateGeometry()
 	// Compute some values that we will use for applying the
 	// texture coordinates.
 	//
-	float left   = static_cast<float>(m_textureRect.left);
-	float right  = left + m_textureRect.width;
-	float top    = static_cast<float>(m_textureRect.top);
-	float bottom = top + m_textureRect.height;
+	float left   = static_cast<float>(m_textureRect.position.x);
+	float right  = left + m_textureRect.size.x;
+	float top    = static_cast<float>(m_textureRect.position.y);
+	float bottom = top + m_textureRect.size.y;
 	sf::Color vert_colour = m_vertices[0].color;
 
 	sf::Vector2f scale = getScale();
@@ -278,19 +278,19 @@ void FeSprite::updateGeometry()
 		//
 		const int SLICES = 253;
 
-		float bws = (float)bounds.width / SLICES;
+		float bws = (float)bounds.size.x / SLICES;
 		float pys = (float)spinch.y / SLICES;
 		float sys = (float)sskew.y / SLICES;
 		float bpxs = bws - (float)spinch.x * 2 / SLICES;
 
 		m_vertices.resize( SLICES + 3 );
-		m_vertices.setPrimitiveType( sf::TrianglesStrip );
+		m_vertices.setPrimitiveType( sf::PrimitiveType::TriangleStrip );
 
 		//
 		// First do the vertex coordinates
 		//
 		m_vertices[0].position = sf::Vector2f(0, 0 );
-		m_vertices[1].position = sf::Vector2f(sskew.x + spinch.x, bounds.height );
+		m_vertices[1].position = sf::Vector2f(sskew.x + spinch.x, bounds.size.y );
 
 		for ( int i=1; i<SLICES; i++ )
 		{
@@ -302,17 +302,17 @@ void FeSprite::updateGeometry()
 			else
 			{
 				m_vertices[1 + i].position = sf::Vector2f(
-						sskew.x + spinch.x + bpxs * i, bounds.height - ( pys - sys ) * i );
+						sskew.x + spinch.x + bpxs * i, bounds.size.y - ( pys - sys ) * i );
 			}
 		}
-		m_vertices[SLICES + 1].position = sf::Vector2f( bounds.width, spinch.y + sskew.y );
+		m_vertices[SLICES + 1].position = sf::Vector2f( bounds.size.x, spinch.y + sskew.y );
 		m_vertices[SLICES + 2].position = sf::Vector2f(
-						sskew.x + bounds.width - spinch.x, bounds.height - spinch.y + sskew.y );
+						sskew.x + bounds.size.x - spinch.x, bounds.size.y - spinch.y + sskew.y );
 
 		//
 		// Now do the texture coordinates
 		//
-		float tws = (float)m_textureRect.width / SLICES;
+		float tws = (float)m_textureRect.size.x / SLICES;
 
 		m_vertices[0].texCoords = sf::Vector2f(left, top );
 		m_vertices[1].texCoords = sf::Vector2f(left, bottom );
@@ -331,12 +331,12 @@ void FeSprite::updateGeometry()
 		// If we aren't pinching the image, then we draw it on two triangles.
 		//
 		m_vertices.resize( 4 );
-		m_vertices.setPrimitiveType( sf::TrianglesStrip );
+		m_vertices.setPrimitiveType( sf::PrimitiveType::TriangleStrip );
 
 		m_vertices[0].position = sf::Vector2f(0, 0);
-		m_vertices[1].position = sf::Vector2f(sskew.x, bounds.height);
-		m_vertices[2].position = sf::Vector2f(bounds.width, sskew.y );
-		m_vertices[3].position = sf::Vector2f(bounds.width + sskew.x, bounds.height + sskew.y);
+		m_vertices[1].position = sf::Vector2f(sskew.x, bounds.size.y);
+		m_vertices[2].position = sf::Vector2f(bounds.size.x, sskew.y );
+		m_vertices[3].position = sf::Vector2f(bounds.size.x + sskew.x, bounds.size.y + sskew.y);
 
 		m_vertices[0].texCoords = sf::Vector2f(left, top);
 		m_vertices[1].texCoords = sf::Vector2f(left, bottom);

--- a/src/swf.cpp
+++ b/src/swf.cpp
@@ -55,8 +55,11 @@ namespace
 	static tu_file *swf_file_opener( const char *url )
 	{
 		if ( swf_zip )
+		{
+			std::optional<std::uint64_t> size = swf_zip->getSize();
 			return new tu_file( tu_file::memory_buffer,
-				swf_zip->getSize(), swf_zip->getData() );
+				size ? static_cast<int>(*size) : 0, swf_zip->getData() );
+		}
 		else
 			return new tu_file(url, "rb");
 	}
@@ -220,8 +223,8 @@ bool FeSwf::open_from_file( const std::string &file )
 	if ( m_imp->root == NULL )
 		return false;
 
-	m_texture.create( m_imp->root->get_movie_width(),
-		m_imp->root->get_movie_height() );
+	m_texture.resize( sf::Vector2u( m_imp->root->get_movie_width(),
+		m_imp->root->get_movie_height() ) );
 
 	m_texture.setSmooth( true );
 

--- a/src/tp.cpp
+++ b/src/tp.cpp
@@ -23,18 +23,24 @@
 #include "tp.hpp"
 #include <iostream>
 #include <cmath>
+#include <cstdint>
 
 // included for SFML_VERSION_INT macros
 #include "fe_util.hpp"
 
+namespace
+{
+	sf::Font s_emptyFont;
+}
+
 FeTextPrimative::FeTextPrimative( )
-	: m_texts( 1, sf::Text() ),
-	m_align( Centre ),
+	: m_align( Centre ),
 	m_first_line( -1 ),
 	m_margin( -1 ),
 	m_line_spacing( 1.0 ),
 	m_needs_pos_set( false )
 {
+	m_texts.push_back( sf::Text( s_emptyFont ) );
 	setColor( sf::Color::White );
 	setBgColor( sf::Color::Transparent );
 }
@@ -45,13 +51,13 @@ FeTextPrimative::FeTextPrimative(
 			const sf::Color &bgcolour,
 			unsigned int charactersize,
 			Alignment align )
-	: m_texts( 1, sf::Text() ),
-	m_align( align ),
+	: m_align( align ),
 	m_first_line( -1 ),
 	m_margin( -1 ),
 	m_line_spacing( 1.0 ),
 	m_needs_pos_set( false )
 {
+	m_texts.push_back( sf::Text( s_emptyFont ) );
 	if ( font )
 		setFont( *font );
 
@@ -102,7 +108,7 @@ const sf::Color &FeTextPrimative::getBgColor() const
 }
 
 void FeTextPrimative::fit_string(
-			const std::basic_string<sf::Uint32> &s,
+			const std::basic_string<std::uint32_t> &s,
 			int &position,
 			int &first_char,
 			int &last_char )
@@ -126,7 +132,7 @@ void FeTextPrimative::fit_string(
 	const sf::Font *font = getFont();
 	unsigned int charsize = m_texts[0].getCharacterSize();
 	unsigned int spacing = charsize;
-	float width = m_bgRect.getLocalBounds().width / m_texts[0].getScale().x;
+	float width = m_bgRect.getLocalBounds().size.x / m_texts[0].getScale().x;
 
 	int running_total( 0 );
 	int running_width( 0 );
@@ -143,10 +149,10 @@ void FeTextPrimative::fit_string(
 		width -= m_margin * 2.0;
 
 	if ( !edit_mode )
-		running_total = -g->bounds.left;
+		running_total = -g->bounds.position.x;
 
 	// We need to adjust the width to make sure that at least one character is displayed per line
-	width = std::max( width, (float)g->bounds.width );
+	width = std::max( width, (float)g->bounds.size.x );
 
 	while (( running_width <= width ) && (( i < (int)s.size() ) || (( m_first_line < 0 ) && ( j > 0 ))))
 	{
@@ -159,7 +165,7 @@ void FeTextPrimative::fit_string(
 			}
 
 			g = &font->getGlyph( s[i], charsize, false );
-			running_width = std::max( running_width, (int)( running_total + g->bounds.left + g->bounds.width ));
+			running_width = std::max( running_width, (int)( running_total + g->bounds.position.x + g->bounds.size.x ));
 			running_total += g->advance;
 
 			if ( s[i] == L' ' )
@@ -184,7 +190,7 @@ void FeTextPrimative::fit_string(
 			kerning = font->getKerning( s[j], s[std::min( j + 1, (int)s.size() - 1 )], charsize );
 			running_total += kerning;
 			g = &font->getGlyph( s[j], charsize, false );
-			running_width = std::max( running_width, (int)( running_total + g->bounds.left + g->bounds.width ));
+			running_width = std::max( running_width, (int)( running_total + g->bounds.position.x + g->bounds.size.x ));
 			running_total += g->advance;
 		}
 	}
@@ -224,7 +230,7 @@ void FeTextPrimative::setString( const std::string &t )
 	// UTF-8 character encoding is assumed.
 	// Need to convert to UTF-32 before giving string to SFML
 	//
-	std::basic_string<sf::Uint32> tmp;
+	std::basic_string<std::uint32_t> tmp;
 	sf::Utf8::toUtf32( t.begin(), t.end(), std::back_inserter( tmp ));
 
 	// We need to add one trailing space to the string
@@ -236,7 +242,7 @@ void FeTextPrimative::setString( const std::string &t )
 }
 
 sf::Vector2f FeTextPrimative::setString(
-			const std::basic_string<sf::Uint32> &t,
+			const std::basic_string<std::uint32_t> &t,
 			int position )
 {
 	//
@@ -249,7 +255,7 @@ sf::Vector2f FeTextPrimative::setString(
 		position = -1;
 
 	if ( m_texts.size() > 1 )
-		m_texts.resize( 1 );
+		m_texts.erase( m_texts.begin() + 1, m_texts.end() );
 
 	const sf::Font *font = getFont();
 
@@ -268,7 +274,10 @@ sf::Vector2f FeTextPrimative::setString(
 		}
 	}
 
-	m_texts[0].setString( t.substr( first_char, last_char - first_char + 1 ));
+	{
+		std::u32string u32str(t.substr( first_char, last_char - first_char + 1 ).begin(), t.substr( first_char, last_char - first_char + 1 ).end());
+		m_texts[0].setString(u32str);
+	}
 
 	disp_cpos -= first_char;
 
@@ -283,7 +292,7 @@ sf::Vector2f FeTextPrimative::setString(
 		sf::FloatRect rectSize = m_bgRect.getLocalBounds();
 
 		const sf::Glyph *glyph = &font->getGlyph( L'X', m_texts[0].getCharacterSize(), false );
-		float glyphSize = glyph->bounds.height * m_texts[0].getScale().y;
+		float glyphSize = glyph->bounds.size.y * m_texts[0].getScale().y;
 
 		int spacing = getLineSpacingFactored( font, floorf( m_texts[0].getCharacterSize() * m_texts[0].getScale().y ));
 		float default_spacing = font->getLineSpacing( m_texts[0].getCharacterSize() ) * m_texts[0].getScale().y;
@@ -293,12 +302,12 @@ sf::Vector2f FeTextPrimative::setString(
 		if ( m_align & ( Top | Bottom | Middle ))
 		{
 			if ( m_margin < 0 )
-				line_count = std::max( 1, (int)floorf(( rectSize.height + spacing - default_spacing - glyphSize ) / spacing ));
+				line_count = std::max( 1, (int)floorf(( rectSize.size.y + spacing - default_spacing - glyphSize ) / spacing ));
 			else
-				line_count = std::max( 1, (int)floorf(( rectSize.height + spacing - glyphSize - m_margin * 2.0 ) / spacing ));
+				line_count = std::max( 1, (int)floorf(( rectSize.size.y + spacing - glyphSize - m_margin * 2.0 ) / spacing ));
 		}
 		else
-			line_count = std::max( 1, (int)( rectSize.height / spacing ));
+			line_count = std::max( 1, (int)( rectSize.size.y / spacing ));
 
 		//
 		// We break the string to lines here starting from the second line
@@ -309,7 +318,10 @@ sf::Vector2f FeTextPrimative::setString(
 			if ( position >= (int)t.size() ) break;
 			fit_string( t, position, first_char, last_char );
 			m_texts.push_back( m_texts[0] );
-			m_texts.back().setString( t.substr( first_char, last_char - first_char + 1 ));
+			{
+				std::u32string u32str(t.substr( first_char, last_char - first_char + 1 ).begin(), t.substr( first_char, last_char - first_char + 1 ).end());
+				m_texts.back().setString(u32str);
+			}
 			actual_line_count++;
 		}
 
@@ -349,30 +361,30 @@ void FeTextPrimative::set_positions() const
 
 		// we need to account for the scaling that we have applied to our text...
 		sf::FloatRect textSize = m_texts[i].getLocalBounds();
-		textSize.width *= m_texts[i].getScale().x;
-		textSize.height *= m_texts[i].getScale().y;
-		textSize.left *= m_texts[i].getScale().x;
+		textSize.size.x *= m_texts[i].getScale().x;
+		textSize.size.y *= m_texts[i].getScale().y;
+		textSize.position.x *= m_texts[i].getScale().x;
 
 		// set position x
 		if ( m_align & Left )
 			textPos.x = rectPos.x;
 		else if ( m_align & Right )
-			textPos.x = rectPos.x + floorf( rectSize.width ) - textSize.width;
+			textPos.x = rectPos.x + floorf( rectSize.size.x ) - textSize.size.x;
 		else if ( m_align & Centre )
-			textPos.x = rectPos.x + floorf(( rectSize.width - textSize.width ) / 2.0 );
+			textPos.x = rectPos.x + floorf(( rectSize.size.x - textSize.size.x ) / 2.0 );
 
 		if ( m_align & ( Top | Bottom | Middle ))
-			textPos.x -= textSize.left;
+			textPos.x -= textSize.position.x;
 
 		// set position y
 		if ( m_align & Top )
 			textPos.y = rectPos.y + ceilf( spacing * i - charSize + glyphSize );
 		else if ( m_align & Bottom )
-			textPos.y = rectPos.y + floorf( rectSize.height  - charSize - spacing * ( m_texts.size() - i - 1 ));
+			textPos.y = rectPos.y + floorf( rectSize.size.y  - charSize - spacing * ( m_texts.size() - i - 1 ));
 		else if ( m_align & Middle )
-			textPos.y = rectPos.y + ceilf( spacing * i + ( rectSize.height + glyphSize - charSize * 2 - spacing * ( m_texts.size() - 1 )) / 2.0 );
+			textPos.y = rectPos.y + ceilf( spacing * i + ( rectSize.size.y + glyphSize - charSize * 2 - spacing * ( m_texts.size() - 1 )) / 2.0 );
 		else
-			textPos.y = rectPos.y + ceilf( spacing * i + ( rectSize.height - ( spacing * m_texts.size() )) / 2.0 );
+			textPos.y = rectPos.y + ceilf( spacing * i + ( rectSize.size.y - ( spacing * m_texts.size() )) / 2.0 );
 
 		if ( m_align & Top ) textPos.y += margin;
 		if ( m_align & Bottom ) textPos.y -= margin;
@@ -380,7 +392,7 @@ void FeTextPrimative::set_positions() const
 		if ( m_align & Right ) textPos.x -= margin;
 
 		sf::Transform trans;
-		trans.rotate( m_bgRect.getRotation(), rectPos.x, rectPos.y );
+		trans.rotate( m_bgRect.getRotation(), rectPos );
 		m_texts[i].setPosition( trans.transformPoint( textPos ) );
 		m_texts[i].setRotation( m_bgRect.getRotation() );
 	}
@@ -395,10 +407,10 @@ int FeTextPrimative::getActualWidth()
 	for ( unsigned int i=0; i < m_texts.size(); i++ )
 	{
 		sf::FloatRect textSize = m_texts[i].getLocalBounds();
-		textSize.width = ceilf( textSize.width * m_texts[i].getScale().x );
+		textSize.size.x = ceilf( textSize.size.x * m_texts[i].getScale().x );
 
-		if ( textSize.width > w )
-			w = textSize.width;
+		if ( textSize.size.x > w )
+			w = textSize.size.x;
 	}
 
 	return (int)w;
@@ -414,7 +426,7 @@ void FeTextPrimative::setFont( const sf::Font &font )
 
 const sf::Font *FeTextPrimative::getFont() const
 {
-	return m_texts[0].getFont();
+	return &m_texts[0].getFont();
 }
 
 void FeTextPrimative::setCharacterSize( unsigned int size )
@@ -435,7 +447,7 @@ unsigned int FeTextPrimative::getGlyphSize() const
 	const sf::Font *font = getFont();
 	const int charSize = m_texts[0].getCharacterSize();
 	const sf::Glyph *glyph = &font->getGlyph( L'X', charSize, false );
-	return floorf(glyph->bounds.height * m_texts[0].getScale().y);
+	return floorf(glyph->bounds.size.y * m_texts[0].getScale().y);
 }
 
 void FeTextPrimative::setCharacterSpacing( float factor )
@@ -526,13 +538,13 @@ void FeTextPrimative::setOutlineThickness( int i )
 
 void FeTextPrimative::setRotation( float r )
 {
-	m_bgRect.setRotation( r );
+	m_bgRect.setRotation( sf::degrees( r ) );
 	m_needs_pos_set = true;
 }
 
 float FeTextPrimative::getRotation() const
 {
-	return m_bgRect.getRotation();
+	return m_bgRect.getRotation().asDegrees();
 }
 
 int FeTextPrimative::getStyle() const

--- a/src/tp.hpp
+++ b/src/tp.hpp
@@ -25,6 +25,7 @@
 
 #include <SFML/Graphics.hpp>
 #include <vector>
+#include <cstdint>
 
 class FeTextPrimative : public sf::Drawable
 {
@@ -60,7 +61,7 @@ public:
 	// that WordWrap is set to false (cursor positioning is not supported
 	// with // wordwrapping on)
 	//
-	sf::Vector2f setString( const std::basic_string<sf::Uint32> &t,
+	sf::Vector2f setString( const std::basic_string<std::uint32_t> &t,
 					int cursor_string_pos=-1 ); // no utf-8 conversion
 
 	void setFont( const sf::Font & );
@@ -130,7 +131,7 @@ private:
 	//		[out] last_char		- position of the last character to display
 	//
 	void fit_string(
-			const std::basic_string<sf::Uint32> &s,
+			const std::basic_string<std::uint32_t> &s,
 			int &position,
 			int &first_char,
 			int &last_char );

--- a/src/zip.cpp
+++ b/src/zip.cpp
@@ -365,13 +365,13 @@ bool FeZipStream::open( const std::string &filename )
 		m_data );
 }
 
-sf::Int64 FeZipStream::read( void *data, sf::Int64 size )
+std::optional<std::size_t> FeZipStream::read( void *data, std::size_t size )
 {
 	if ( m_data.empty() )
-		return -1;
+		return std::nullopt;
 
-	sf::Int64 end_pos = m_pos + size;
-	size_t count = ( end_pos <= (sf::Int64)m_data.size() )
+	std::size_t end_pos = m_pos + size;
+	std::size_t count = ( end_pos <= m_data.size() )
 		? size : ( m_data.size() - m_pos );
 
 	if ( count > 0 )
@@ -383,27 +383,27 @@ sf::Int64 FeZipStream::read( void *data, sf::Int64 size )
 	return count;
 }
 
-sf::Int64 FeZipStream::seek( sf::Int64 position )
+std::optional<std::size_t> FeZipStream::seek( std::size_t position )
 {
 	if ( m_data.empty() )
-		return -1;
+		return std::nullopt;
 
-	m_pos = ( position < (sf::Int64)m_data.size() ) ? position : m_data.size();
+	m_pos = ( position < m_data.size() ) ? position : m_data.size();
 	return m_pos;
 }
 
-sf::Int64 FeZipStream::tell()
+std::optional<std::size_t> FeZipStream::tell()
 {
 	if ( m_data.empty() )
-		return -1;
+		return std::nullopt;
 
 	return m_pos;
 }
 
-sf::Int64 FeZipStream::getSize()
+std::optional<std::size_t> FeZipStream::getSize()
 {
 	if ( m_data.empty() )
-		return -1;
+		return std::nullopt;
 
 	return m_data.size();
 }

--- a/src/zip.hpp
+++ b/src/zip.hpp
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 #include <SFML/System/InputStream.hpp>
-#include <SFML/System/NonCopyable.hpp>
+#include <cstdint>
 
 typedef void *(*FE_ZIP_ALLOC_CALLBACK) ( size_t );
 bool fe_zip_open_to_buff(
@@ -64,7 +64,7 @@ bool get_archive_filename_with_base(
 extern const char *FE_ARCHIVE_EXT[];
 bool is_supported_archive( const std::string & );
 
-class FeZipStream : public sf::InputStream, sf::NonCopyable
+class FeZipStream : public sf::InputStream
 {
 public:
 	FeZipStream();
@@ -72,12 +72,15 @@ public:
 
 	~FeZipStream();
 
-	bool open( const std::string &filename );
-	sf::Int64 read( void *data, sf::Int64 size ); // virtual
+	FeZipStream( const FeZipStream& ) = delete;
+	FeZipStream& operator=( const FeZipStream& ) = delete;
 
-	sf::Int64 seek( sf::Int64 position );
-	sf::Int64 tell();
-	sf::Int64 getSize();
+	bool open( const std::string &filename );
+	std::optional<std::size_t> read( void *data, std::size_t size ) override;
+
+	std::optional<std::size_t> seek( std::size_t position ) override;
+	std::optional<std::size_t> tell() override;
+	std::optional<std::size_t> getSize() override;
 	void setArchive( const std::string &archive );
 	char *getData();
 
@@ -86,7 +89,7 @@ private:
 
 	std::string m_archive;
 	std::vector < char > m_data;
-	sf::Int64 m_pos;
+	std::size_t m_pos;
 };
 
 #endif


### PR DESCRIPTION
- Update video mode API: vm.width/height -> vm.size.x/y
- Migrate event handling to new SFML 3 API: ev.is<T>() and ev.getIf<T>()
- Add window state mapping using sf::State enum
- Replace deprecated getSystemHandle() with getNativeHandle()
- Update SoundStream API for SFML 3